### PR TITLE
Add standardized experiment framework and analytics app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+outputs/

--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -1,0 +1,68 @@
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _default(obj: Any) -> Any:
+    """JSON serializer for objects not serializable by default json code."""
+    if isinstance(obj, (datetime,)):
+        return obj.isoformat()
+    return str(obj)
+
+
+@dataclass
+class ExperimentResult:
+    """Container for standardized experiment results."""
+    experiment_name: str
+    dataset: str
+    model: str
+    params: Dict[str, Any]
+    metrics: Dict[str, float]
+    epsilon: float
+    delta: float
+    timestamp: datetime = datetime.utcnow()
+
+    def to_json(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["timestamp"] = self.timestamp.isoformat()
+        return data
+
+
+def save_result(result: ExperimentResult, output_path: str) -> Path:
+    """Save an ExperimentResult to ``output_path`` as JSON.
+
+    The directory is created if necessary. The function returns the
+    :class:`pathlib.Path` to the written file.
+    """
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(result.to_json(), f, indent=2, default=_default)
+    return path
+
+
+def load_results(pattern: str) -> Dict[str, ExperimentResult]:
+    """Load multiple results matching ``pattern`` (glob).
+
+    The ``pattern`` can be relative or absolute and may include wildcards.
+    Returns a mapping from filename to :class:`ExperimentResult` objects."""
+    import glob
+
+    loaded: Dict[str, ExperimentResult] = {}
+    for name in glob.glob(pattern):
+        fp = Path(name)
+        with fp.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        loaded[fp.name] = ExperimentResult(
+            experiment_name=data["experiment_name"],
+            dataset=data["dataset"],
+            model=data["model"],
+            params=data.get("params", {}),
+            metrics=data.get("metrics", {}),
+            epsilon=data.get("epsilon", 0.0),
+            delta=data.get("delta", 0.0),
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+        )
+    return loaded

--- a/experiments/dp_lasso_experiment.ipynb
+++ b/experiments/dp_lasso_experiment.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DP LASSO Experiment\n",
+    "Simple demonstration of a differentially private LASSO estimator with standardized output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn import datasets, linear_model\n",
+    "from experiment_utils import ExperimentResult, save_result\n",
+    "import gdrive_utils\n",
+    "\n",
+    "X, y = datasets.make_regression(n_samples=100, n_features=20, random_state=0)\n",
+    "lasso = linear_model.Lasso(alpha=0.1).fit(X, y)\n",
+    "baseline_mse = np.mean((lasso.predict(X) - y)**2)\n",
+    "\n",
+    "# naive DP approach: add Laplace noise to features\n",
+    "noisy_X = X + np.random.laplace(scale=1.0, size=X.shape)\n",
+    "dp_lasso = linear_model.Lasso(alpha=0.1).fit(noisy_X, y)\n",
+    "dp_mse = np.mean((dp_lasso.predict(X) - y)**2)\n",
+    "\n",
+    "result = ExperimentResult(\n",
+    "    experiment_name='dp_lasso_demo',\n",
+    "    dataset='synthetic',\n",
+    "    model='lasso',\n",
+    "    params={'alpha':0.1},\n",
+    "    metrics={'baseline_mse':float(baseline_mse), 'dp_mse':float(dp_mse)},\n",
+    "    epsilon=1.0,\n",
+    "    delta=1e-5\n",
+    ")\n",
+    "output_path = save_result(result, 'outputs/dp_lasso.json')\n",
+    "gdrive_utils.upload_file_to_gdrive(str(output_path), 'GDRIVE_FOLDER_ID')\n",
+    "result.to_json()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/experiments/dp_mixup_experiment.ipynb
+++ b/experiments/dp_mixup_experiment.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DP Mixup Experiment\n",
+    "Demonstrates differentially private mixup training and outputs standardized JSON results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn, optim\n",
+    "from torchvision import datasets, transforms\n",
+    "from opacus import PrivacyEngine\n",
+    "import numpy as np\n",
+    "from experiment_utils import ExperimentResult, save_result\n",
+    "import gdrive_utils\n",
+    "\n",
+    "def mixup_data(x, y, alpha=0.4):\n",
+    "    lam = np.random.beta(alpha, alpha)\n",
+    "    index = torch.randperm(x.size(0))\n",
+    "    mixed_x = lam * x + (1 - lam) * x[index, :]\n",
+    "    y_a, y_b = y, y[index]\n",
+    "    return mixed_x, y_a, y_b, lam\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# prepare data/model and run a single training step for demo\n",
+    "train_loader = torch.utils.data.DataLoader(\n",
+    "    datasets.MNIST('data', download=True, transform=transforms.ToTensor()),\n",
+    "    batch_size=64, shuffle=True\n",
+    ")\n",
+    "model = nn.Sequential(nn.Flatten(), nn.Linear(28*28, 10))\n",
+    "optimizer = optim.SGD(model.parameters(), lr=0.1)\n",
+    "privacy_engine = PrivacyEngine()\n",
+    "model, optimizer, train_loader = privacy_engine.make_private_with_epsilon(\n",
+    "    module=model,\n",
+    "    optimizer=optimizer,\n",
+    "    data_loader=train_loader,\n",
+    "    epochs=1,\n",
+    "    target_epsilon=1.0,\n",
+    "    target_delta=1e-5,\n",
+    "    max_grad_norm=1.0,\n",
+    ")\n",
+    "\n",
+    "criterion = nn.CrossEntropyLoss()\n",
+    "x, y = next(iter(train_loader))\n",
+    "mixed_x, y_a, y_b, lam = mixup_data(x, y)\n",
+    "optimizer.zero_grad()\n",
+    "pred = model(mixed_x)\n",
+    "loss = lam * criterion(pred, y_a) + (1-lam) * criterion(pred, y_b)\n",
+    "loss.backward()\n",
+    "optimizer.step()\n",
+    "\n",
+    "epsilon = privacy_engine.get_epsilon(1e-5)\n",
+    "result = ExperimentResult(\n",
+    "    experiment_name='dp_mixup_demo',\n",
+    "    dataset='MNIST',\n",
+    "    model='fc',\n",
+    "    params={'batch_size':64, 'alpha':0.4},\n",
+    "    metrics={'loss':float(loss.item())},\n",
+    "    epsilon=epsilon,\n",
+    "    delta=1e-5\n",
+    ")\n",
+    "output_path = save_result(result, 'outputs/dp_mixup.json')\n",
+    "gdrive_utils.upload_file_to_gdrive(str(output_path), 'GDRIVE_FOLDER_ID')\n",
+    "result.to_json()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gdrive_utils.py
+++ b/gdrive_utils.py
@@ -1,0 +1,40 @@
+"""Utility helpers for uploading files to Google Drive."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+try:
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaFileUpload
+except Exception:  # pragma: no cover - dependencies may be missing during tests
+    service_account = build = MediaFileUpload = None
+
+
+def upload_file_to_gdrive(
+    local_path: str, folder_id: str, credentials_file: Optional[str] = None
+) -> Optional[str]:
+    """Upload ``local_path`` to Google Drive ``folder_id``.
+
+    Returns the file ID on success. If the Google libraries are not available,
+    the function returns ``None`` without raising errors, which makes it safe
+    to call in environments without Google credentials."""
+    if build is None:
+        return None
+
+    creds = None
+    if credentials_file:
+        creds = service_account.Credentials.from_service_account_file(
+            credentials_file, scopes=["https://www.googleapis.com/auth/drive.file"]
+        )
+
+    service = build("drive", "v3", credentials=creds)
+    file_metadata = {"name": Path(local_path).name, "parents": [folder_id]}
+    media = MediaFileUpload(local_path, resumable=True)
+    file = (
+        service.files()
+        .create(body=file_metadata, media_body=media, fields="id")
+        .execute()
+    )
+    return file.get("id")

--- a/tests/test_experiment_utils.py
+++ b/tests/test_experiment_utils.py
@@ -1,0 +1,24 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from experiment_utils import ExperimentResult, save_result, load_results
+
+
+def test_save_and_load(tmp_path):
+    res = ExperimentResult(
+        experiment_name="demo",
+        dataset="ds",
+        model="model",
+        params={"a": 1},
+        metrics={"loss": 0.1},
+        epsilon=1.0,
+        delta=1e-5,
+    )
+    out = tmp_path / "res.json"
+    save_result(res, out.as_posix())
+    loaded = load_results(out.as_posix())["res.json"]
+    assert loaded.experiment_name == "demo"
+    assert loaded.metrics["loss"] == 0.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,23 @@
+import glob
+import json
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from experiment_utils import load_results
+
+st.title("DP Experiment Dashboard")
+
+# Load experiment results
+results = load_results("outputs/*.json")
+if not results:
+    st.info("No experiment results found. Run experiments to generate JSON outputs.")
+else:
+    records = [r.to_json() for r in results.values()]
+    df = pd.DataFrame(records)
+    st.dataframe(df)
+    metric_cols = [col for col in df.columns if col not in {"params", "metrics"}]
+    st.write("Summary Metrics")
+    metrics_df = pd.json_normalize(df["metrics"])
+    st.dataframe(pd.concat([df[metric_cols], metrics_df], axis=1))


### PR DESCRIPTION
## Summary
- add utilities for logging experiment results to standardized JSON and loading them
- provide DP Mixup and DP LASSO demonstration notebooks that export results and optional upload to Google Drive
- prototype Streamlit analytics dashboard for visualizing experiment outputs
- include helper for optional Google Drive uploads and basic tests for result logging

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689157ed78908326b3dd0677408266e4