### PR TITLE
Add unit tests for dp_pipeline

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Convenience script to run all unit tests in the repository."""
+import pytest
+
+def main() -> int:
+    """Execute the test suite via pytest."""
+    return pytest.main(["-q"])
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import json
+from dp_pipeline import ExperimentConfig, save_results_json, current_timestamp
+
+
+def test_experiment_config_to_dict():
+    config = ExperimentConfig(experiment_name="test", method="sgd")
+    cfg_dict = config.to_dict()
+    assert cfg_dict["experiment_name"] == "test"
+    assert cfg_dict["method"] == "sgd"
+
+
+def test_save_results_json(tmp_path):
+    results = {"experiment_name": "exp", "value": 1}
+    file_path = save_results_json(results, tmp_path)
+    with open(file_path, "r", encoding="utf-8") as f:
+        loaded = json.load(f)
+    assert loaded == results
+
+
+def test_current_timestamp_format():
+    ts = current_timestamp()
+    # ISO 8601 with Z suffix for UTC
+    assert ts.endswith("Z")
+    # Ensure string can be parsed
+    import datetime as _dt
+    _dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,7 @@
+import pytest
+from dp_pipeline import get_cifar10_dataloaders
+
+
+def test_get_cifar10_dataloaders_requires_torch():
+    with pytest.raises(RuntimeError):
+        get_cifar10_dataloaders(batch_size=4)

--- a/tests/test_lasso.py
+++ b/tests/test_lasso.py
@@ -1,0 +1,20 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+sklearn = pytest.importorskip("sklearn")
+from sklearn.datasets import make_regression
+
+from dp_pipeline import ExperimentConfig, dp_lasso
+
+
+def test_dp_lasso_runs_and_returns_metrics():
+    X, y = make_regression(n_samples=50, n_features=5, noise=0.1, random_state=0)
+    X_train, X_test = X[:40], X[40:]
+    y_train, y_test = y[:40], y[40:]
+    config = ExperimentConfig(
+        experiment_name="lasso", method="dp_lasso", noise_multiplier=0.1, lasso_alpha=0.01
+    )
+    results = dp_lasso(config, X_train, y_train, X_test, y_test)
+    assert results["model"] == "Lasso"
+    assert "train_mse" in results["metrics"]
+    assert "test_mse" in results["metrics"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,7 @@
+import pytest
+from dp_pipeline import resnet20
+
+
+def test_resnet20_requires_torch():
+    with pytest.raises(RuntimeError):
+        resnet20()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,17 @@
+import pytest
+from dp_pipeline import ExperimentConfig, train_dp_sgd, train_dp_mixup
+
+
+def test_train_dp_sgd_requires_dependencies():
+    config = ExperimentConfig(experiment_name="e", method="sgd")
+    with pytest.raises(RuntimeError):
+        train_dp_sgd(config, None, None)
+
+
+def test_train_dp_mixup_checks_params_and_dependencies():
+    config = ExperimentConfig(experiment_name="e", method="mixup")
+    with pytest.raises(ValueError):
+        train_dp_mixup(config, None, None)
+    config.mixup_alpha = 0.1
+    with pytest.raises(RuntimeError):
+        train_dp_mixup(config, None, None)


### PR DESCRIPTION
## Summary
- add tests for ExperimentConfig serialization, timestamp formatting, and results saving
- cover dependency checks in data loaders, models, and training helpers
- verify dp_lasso returns expected metrics
- add `run_tests.py` convenience script to execute the full test suite

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_689178804ddc83268059e626c575078f