### PR TITLE
Add Jupyter dependency for notebook execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ streamlit==1.33.0
 
 # Notebook kernel support (needed for registering the environment as a Jupyter kernel)
 ipykernel==6.29.4
+
+# Jupyter environment for executing notebooks
+jupyter==1.1.1


### PR DESCRIPTION
## Summary
- ensure dp_experiments_unified notebook can run by adding missing Jupyter dependency

## Testing
- `jupyter nbconvert --to notebook --execute dp_experiments_unified.ipynb`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68917b9db0148326afa5601567534846