### PR TITLE
Create modular DP experiment framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+outputs/*
+!outputs/.gitkeep

--- a/privacy_pipeline/__init__.py
+++ b/privacy_pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental framework for privacy-preserving training."""

--- a/privacy_pipeline/config.py
+++ b/privacy_pipeline/config.py
@@ -1,0 +1,45 @@
+import torch
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+def default_device() -> torch.device:
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@dataclass
+class ExperimentConfig:
+    """Holds hyperparameters for a DP experiment."""
+
+    # training hyperparameters
+    seed: int = 0
+    batch_size: int = 512
+    lr: float = 0.05
+    outer_momentum: float = 0.9
+    inner_momentum: float = 0.10
+    noise_mult: float = 1.0
+    delta: float = 1e-5
+    num_epochs: int = 20
+
+    # clipping schedule
+    c_start: float = 4.0
+    c_end: float = 2.0
+
+    # dataset and augmentation
+    self_aug_factor: int = 3
+    dataset_mean: Tuple[float, float, float] = field(
+        default_factory=lambda: (0.4914, 0.4822, 0.4465)
+    )
+    dataset_std: Tuple[float, float, float] = field(
+        default_factory=lambda: (0.2470, 0.2435, 0.2616)
+    )
+
+    # LR schedule
+    schedule_milestones: List[int] = field(default_factory=lambda: [12, 18])
+    schedule_gamma: float = 0.1
+
+    # momentum dictionary size
+    max_momentum_size: int = 10000
+
+    # device
+    device: torch.device = field(default_factory=default_device)

--- a/privacy_pipeline/data.py
+++ b/privacy_pipeline/data.py
@@ -1,0 +1,50 @@
+import random
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import ConcatDataset, DataLoader, Subset
+from torchvision import datasets, transforms
+
+from .config import ExperimentConfig
+
+
+class IndexedSubset(Subset):
+    """Subset that also returns the original index."""
+
+    def __getitem__(self, idx):
+        x, y = super().__getitem__(idx)
+        return x, y, idx
+
+
+def get_dataloaders(cfg: ExperimentConfig) -> Tuple[DataLoader, DataLoader]:
+    """Creates train and test dataloaders with augmentation."""
+    mean, std = cfg.dataset_mean, cfg.dataset_std
+    train_tf = transforms.Compose([
+        transforms.RandomCrop(32, padding=4),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+        transforms.RandomErasing(p=0.5, scale=(0.02, 0.2)),
+        transforms.Normalize(mean, std),
+    ])
+    test_tf = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize(mean, std),
+    ])
+
+    train_ds = datasets.CIFAR10(root="./data", train=True, download=True, transform=train_tf)
+    test_ds = datasets.CIFAR10(root="./data", train=False, download=True, transform=test_tf)
+
+    n = len(train_ds)
+    train_sub = IndexedSubset(train_ds, range(n))
+    train_full = ConcatDataset([train_sub] * cfg.self_aug_factor)
+
+    train_loader = DataLoader(train_full, batch_size=cfg.batch_size, shuffle=True, drop_last=True)
+    test_loader = DataLoader(test_ds, batch_size=cfg.batch_size, shuffle=False)
+    return train_loader, test_loader
+
+
+def set_random_seeds(seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    np.random.seed(seed)

--- a/privacy_pipeline/grad_ops.py
+++ b/privacy_pipeline/grad_ops.py
@@ -1,0 +1,81 @@
+from typing import Iterable, List, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import torch
+
+
+def clip_sum_noise(
+    batch_v: Sequence[Tuple[int, torch.Tensor]],
+    clip_val: float,
+    noise_mult: float,
+    do_noise: bool = True,
+    return_postclip: bool = False,
+) -> Tuple[torch.Tensor, List[float] | None]:
+    """Clips, sums and adds noise to gradients."""
+    clipped_list = []
+    postclip_norms: List[float] | None = [] if return_postclip else None
+    for (_, g) in batch_v:
+        norm_g = g.norm(2)
+        if norm_g > clip_val:
+            g = g * (clip_val / (norm_g + 1e-9))
+        if return_postclip and postclip_norms is not None:
+            postclip_norms.append(g.norm(2).item())
+        clipped_list.append(g)
+
+    grad_sum = torch.stack(clipped_list, dim=0).sum(dim=0)
+    count = float(len(clipped_list))
+
+    if do_noise:
+        noise = torch.randn_like(grad_sum) * (noise_mult * clip_val)
+        grad_sum += noise
+
+    final_grad = grad_sum / count
+
+    if return_postclip:
+        return final_grad, postclip_norms
+    return final_grad, None
+
+
+def outer_step(dp_model: torch.nn.Module, optimizer, final_grad: torch.Tensor) -> None:
+    idx_start = 0
+    for p in dp_model.parameters():
+        numel = p.numel()
+        chunk = final_grad[idx_start : idx_start + numel]
+        p.grad = chunk.view_as(p)
+        idx_start += numel
+    optimizer.step()
+
+
+def measure_distribution(vecs: Iterable[torch.Tensor]) -> Tuple[List[float], List[float], List[float]]:
+    """Returns L1, L2 and cosine similarity with mean for each vector."""
+    vecs_list = list(vecs)
+    if not vecs_list:
+        return [], [], []
+    stacked = torch.stack(vecs_list, dim=0)
+    mean_vec = stacked.mean(dim=0)
+    mean_norm = mean_vec.norm(2).item() + 1e-9
+
+    l1_list: List[float] = []
+    l2_list: List[float] = []
+    cos_list: List[float] = []
+    for v in vecs_list:
+        l1_list.append(v.norm(p=1).item())
+        l2_list.append(v.norm(p=2).item())
+        dot_val = (v * mean_vec).sum().item()
+        denom = v.norm(2).item() * mean_norm + 1e-9
+        cos_list.append(dot_val / denom)
+    return l1_list, l2_list, cos_list
+
+
+def plot_hist(data: Sequence[float], title: str, bins: int = 50, color: str = "blue", path: str | None = None) -> None:
+    """Plots a histogram of the provided data and saves to ``path`` if given."""
+    plt.figure()
+    plt.hist(data, bins=bins, alpha=0.7, color=color, edgecolor="black")
+    plt.title(title)
+    plt.xlabel("Value")
+    plt.ylabel("Count")
+    if path:
+        plt.savefig(path)
+        plt.close()
+    else:
+        plt.show()

--- a/privacy_pipeline/model.py
+++ b/privacy_pipeline/model.py
@@ -1,0 +1,95 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from opacus.grad_sample import GradSampleModule
+from opacus.validators import ModuleValidator
+
+
+class BasicBlockEnhanced(nn.Module):
+    """ResNet block with ELU and GroupNorm."""
+
+    def __init__(self, in_planes: int, planes: int, stride: int = 1) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_planes, planes, 3, stride, 1, bias=False)
+        self.gn1 = nn.GroupNorm(8, planes)
+
+        self.conv2 = nn.Conv2d(planes, planes, 3, 1, 1, bias=False)
+        self.gn2 = nn.GroupNorm(8, planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, planes, 1, stride, bias=False),
+                nn.GroupNorm(8, planes),
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.conv1(x)
+        out = F.elu(out)
+        out = self.gn1(out)
+
+        out = self.conv2(out)
+        out = F.elu(out)
+        out = self.gn2(out)
+
+        out = out.clone() + self.shortcut(x)
+        return F.elu(out)
+
+
+class ResNet20Enhanced(nn.Module):
+    def __init__(self, num_classes: int = 10) -> None:
+        super().__init__()
+        self.in_planes = 16
+        self.conv1 = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1, bias=False)
+        self.gn1 = nn.GroupNorm(8, 16)
+
+        self.layer1 = self._make_layer(16, 3, stride=1)
+        self.layer2 = self._make_layer(32, 3, stride=2)
+        self.layer3 = self._make_layer(64, 3, stride=2)
+
+        self.avgpool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Linear(64, num_classes)
+
+    def _make_layer(self, planes: int, num_blocks: int, stride: int) -> nn.Sequential:
+        strides = [stride] + [1] * (num_blocks - 1)
+        layers = []
+        for s in strides:
+            layers.append(BasicBlockEnhanced(self.in_planes, planes, s))
+            self.in_planes = planes
+        return nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.conv1(x)
+        out = F.elu(out)
+        out = self.gn1(out)
+
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+
+        out = self.avgpool(out)
+        out = torch.flatten(out, 1)
+        return self.fc(out)
+
+
+def build_model(device: torch.device) -> GradSampleModule:
+    net = ResNet20Enhanced().to(device)
+    errs = ModuleValidator.validate(net, strict=False)
+    if errs:
+        net = ModuleValidator.fix(net).to(device)
+    return GradSampleModule(net)
+
+
+@torch.no_grad()
+def evaluate(model: nn.Module, loader, device: torch.device) -> float:
+    was_training = model.training
+    model.eval()
+    correct, total = 0, 0
+    for X, y in loader:
+        X, y = X.to(device), y.to(device)
+        preds = model(X).argmax(dim=1)
+        correct += (preds == y).sum().item()
+        total += y.size(0)
+    if was_training:
+        model.train()
+    return 100.0 * correct / total

--- a/privacy_pipeline/momentum.py
+++ b/privacy_pipeline/momentum.py
@@ -1,0 +1,74 @@
+from collections import OrderedDict
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+class LRUOrderedDict(OrderedDict):
+    """OrderedDict with a maximum size implementing LRU eviction."""
+
+    def __init__(self, *args, maxsize: int = 10000, **kwargs) -> None:
+        self.maxsize = maxsize
+        super().__init__(*args, **kwargs)
+
+    def __getitem__(self, key):  # type: ignore[override]
+        val = super().__getitem__(key)
+        self.move_to_end(key)
+        return val
+
+    def __setitem__(self, key, val) -> None:  # type: ignore[override]
+        if key in self:
+            self.move_to_end(key)
+        super().__setitem__(key, val)
+        if len(self) > self.maxsize:
+            self.popitem(last=False)
+
+
+def compute_per_id_momentum(
+    dp_model: torch.nn.Module,
+    X: torch.Tensor,
+    y: torch.Tensor,
+    idxs: torch.Tensor,
+    momentum_dict: LRUOrderedDict,
+    inner_momentum: float,
+    device: torch.device,
+    base_size: int = 50000,
+) -> Tuple[List[Tuple[int, torch.Tensor]], int]:
+    """Computes per-sample gradients with momentum grouped by ID."""
+
+    dp_model.zero_grad()
+    out = dp_model(X)
+    loss = F.cross_entropy(out, y)
+    loss.backward()
+
+    bs = X.size(0)
+    param_vecs: List[torch.Tensor | None] = [None] * bs
+
+    for p in dp_model.parameters():
+        gs = getattr(p, "grad_sample", None)
+        if gs is None:
+            continue
+        gs_flat = gs.view(bs, -1).detach()
+        for i in range(bs):
+            if param_vecs[i] is None:
+                param_vecs[i] = gs_flat[i]
+            else:
+                param_vecs[i] = torch.cat([param_vecs[i], gs_flat[i]], dim=0)
+        p.grad_sample = None
+
+    group_dict: Dict[int, List[torch.Tensor]] = {}
+    for i in range(bs):
+        real_id = int(idxs[i].item()) % base_size
+        v_i = param_vecs[i].to(device)  # type: ignore[index]
+        group_dict.setdefault(real_id, []).append(v_i)
+
+    results: List[Tuple[int, torch.Tensor]] = []
+    for sample_id, v_list in group_dict.items():
+        raw_v = torch.stack(v_list, dim=0).mean(dim=0)
+        old_v = momentum_dict.get(sample_id, torch.zeros_like(raw_v))
+        old_v = old_v.to(device)
+        new_v = (inner_momentum * old_v) + ((1.0 - inner_momentum) * raw_v)
+        momentum_dict[sample_id] = new_v.half().cpu()
+        results.append((sample_id, new_v))
+    return results, len(group_dict)

--- a/privacy_pipeline/training.py
+++ b/privacy_pipeline/training.py
@@ -1,0 +1,171 @@
+import json
+import os
+from typing import Dict, List
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import torch.optim as optim
+from opacus.accountants import RDPAccountant
+
+from .config import ExperimentConfig
+from .data import get_dataloaders, set_random_seeds
+from .grad_ops import clip_sum_noise, measure_distribution, outer_step, plot_hist
+from .momentum import LRUOrderedDict, compute_per_id_momentum
+from .model import build_model, evaluate
+
+
+def _summary_stats(values: List[float]) -> Dict[str, float]:
+    if not values:
+        return {"mean": 0.0, "std": 0.0}
+    return {"mean": float(np.mean(values)), "std": float(np.std(values))}
+
+
+def train(cfg: ExperimentConfig, output_dir: str, plot_every: int = 5) -> Dict[str, List[Dict[str, float]]]:
+    """Runs a DP experiment and stores metrics in ``output_dir``."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    set_random_seeds(cfg.seed)
+    device = cfg.device
+
+    train_loader, test_loader = get_dataloaders(cfg)
+    dp_net = build_model(device).to(device)
+    optimizer = optim.SGD(
+        dp_net.parameters(),
+        lr=cfg.lr,
+        momentum=cfg.outer_momentum,
+        weight_decay=5e-4,
+    )
+    scheduler = optim.lr_scheduler.MultiStepLR(
+        optimizer, milestones=cfg.schedule_milestones, gamma=cfg.schedule_gamma
+    )
+    accountant = RDPAccountant()
+    momentum_dict = LRUOrderedDict(maxsize=cfg.max_momentum_size)
+
+    total_steps = cfg.num_epochs * len(train_loader)
+    step_count = 0
+    history: List[Dict[str, float]] = []
+
+    for epoch in range(1, cfg.num_epochs + 1):
+        dp_net.train()
+        losses: List[float] = []
+        epoch_preclip_l1: List[float] = []
+        epoch_preclip_l2: List[float] = []
+        epoch_preclip_cos: List[float] = []
+        epoch_postclip_l1: List[float] = []
+        epoch_postclip_l2: List[float] = []
+        epoch_postclip_cos: List[float] = []
+
+        for X, y, idxs in train_loader:
+            step_count += 1
+            frac = step_count / float(total_steps)
+            clip_val = cfg.c_start + (cfg.c_end - cfg.c_start) * frac
+
+            X, y = X.to(device), y.to(device)
+            batch_v, unique_count = compute_per_id_momentum(
+                dp_net, X, y, idxs, momentum_dict, cfg.inner_momentum, device
+            )
+            preclip_vecs = [g for (_, g) in batch_v]
+            pre_l1, pre_l2, pre_cos = measure_distribution(preclip_vecs)
+            epoch_preclip_l1.extend(pre_l1)
+            epoch_preclip_l2.extend(pre_l2)
+            epoch_preclip_cos.extend(pre_cos)
+
+            final_grad, _ = clip_sum_noise(
+                batch_v, clip_val, cfg.noise_mult, do_noise=True, return_postclip=True
+            )
+            clipped_vecs = []
+            for (_, raw_v) in batch_v:
+                nm = raw_v.norm(2).item()
+                if nm > clip_val:
+                    clipped_v = raw_v * (clip_val / (nm + 1e-9))
+                else:
+                    clipped_v = raw_v
+                clipped_vecs.append(clipped_v)
+            post_l1, post_l2, post_cos = measure_distribution(clipped_vecs)
+            epoch_postclip_l1.extend(post_l1)
+            epoch_postclip_l2.extend(post_l2)
+            epoch_postclip_cos.extend(post_cos)
+
+            outer_step(dp_net, optimizer, final_grad)
+
+            with torch.no_grad():
+                out = dp_net(X)
+                loss_val = F.cross_entropy(out, y)
+            losses.append(loss_val.item())
+
+            sample_rate = unique_count / 50000.0
+            accountant.step(noise_multiplier=cfg.noise_mult, sample_rate=sample_rate)
+
+        scheduler.step()
+        acc = evaluate(dp_net, test_loader, device)
+        eps = accountant.get_epsilon(cfg.delta)
+
+        epoch_record = {
+            "epoch": epoch,
+            "loss": float(np.mean(losses)) if losses else 0.0,
+            "accuracy": float(acc),
+            "epsilon": float(eps),
+            "preclip_l1": _summary_stats(epoch_preclip_l1),
+            "preclip_l2": _summary_stats(epoch_preclip_l2),
+            "preclip_cos": _summary_stats(epoch_preclip_cos),
+            "postclip_l1": _summary_stats(epoch_postclip_l1),
+            "postclip_l2": _summary_stats(epoch_postclip_l2),
+            "postclip_cos": _summary_stats(epoch_postclip_cos),
+        }
+        history.append(epoch_record)
+
+        print(
+            f"[Epoch {epoch:02d}] clip~{clip_val:.2f} Loss={epoch_record['loss']:.3f} Acc={acc:.2f}% eps={eps:.2f}"
+        )
+
+        if plot_every and epoch % plot_every == 0:
+            plot_hist(
+                epoch_preclip_l1,
+                title=f"Pre-clip L1 norms (epoch={epoch})",
+                color="blue",
+                path=os.path.join(output_dir, f"preclip_l1_epoch{epoch}.png"),
+            )
+            plot_hist(
+                epoch_preclip_l2,
+                title=f"Pre-clip L2 norms (epoch={epoch})",
+                color="green",
+                path=os.path.join(output_dir, f"preclip_l2_epoch{epoch}.png"),
+            )
+            plot_hist(
+                epoch_preclip_cos,
+                title=f"Pre-clip cos sim vs. mean (epoch={epoch})",
+                color="red",
+                path=os.path.join(output_dir, f"preclip_cos_epoch{epoch}.png"),
+            )
+            plot_hist(
+                epoch_postclip_l1,
+                title=f"Post-clip L1 norms (epoch={epoch})",
+                color="blue",
+                path=os.path.join(output_dir, f"postclip_l1_epoch{epoch}.png"),
+            )
+            plot_hist(
+                epoch_postclip_l2,
+                title=f"Post-clip L2 norms (epoch={epoch})",
+                color="green",
+                path=os.path.join(output_dir, f"postclip_l2_epoch{epoch}.png"),
+            )
+            plot_hist(
+                epoch_postclip_cos,
+                title=f"Post-clip cos sim vs. mean (epoch={epoch})",
+                color="red",
+                path=os.path.join(output_dir, f"postclip_cos_epoch{epoch}.png"),
+            )
+
+    final_acc = evaluate(dp_net, test_loader, device)
+    final_eps = accountant.get_epsilon(cfg.delta)
+    print(f"\nDone. Final test Acc={final_acc:.2f}% Eps={final_eps:.2f}")
+
+    results = {
+        "history": history,
+        "final_accuracy": float(final_acc),
+        "final_epsilon": float(final_eps),
+    }
+    with open(os.path.join(output_dir, "metrics.json"), "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+    return results

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -1,0 +1,20 @@
+"""Entry point for running DP experiments."""
+import argparse
+
+from privacy_pipeline.config import ExperimentConfig
+from privacy_pipeline.training import train
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DP experiment")
+    parser.add_argument(
+        "--output-dir", type=str, default="outputs/experiment1", help="Where to store outputs"
+    )
+    args = parser.parse_args()
+
+    cfg = ExperimentConfig()
+    train(cfg, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- modularized DP experiment into reusable package
- add training routine that logs metrics and saves outputs
- provide CLI script for running experiments

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689180a10a1c8326a6a0e819e3648644