### PR TITLE
Add virtual sample and local DP-SGD experiments

### DIFF
--- a/dp_virtual_projection_population_only.py
+++ b/dp_virtual_projection_population_only.py
@@ -1,0 +1,469 @@
+##############################################################
+# Filename: dp_virtual_projection_population_only.py
+# (2025-07-03 patched version)
+##############################################################
+import os, psutil, random, math, time, statistics
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import numpy as np
+import matplotlib.pyplot as plt
+from collections import OrderedDict
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader, ConcatDataset, Subset
+
+# Opacus
+from opacus.validators import ModuleValidator
+from opacus.grad_sample import GradSampleModule
+
+###############################################################################
+# 0. Hyperparameters
+###############################################################################
+seed                 = 0
+random.seed(seed);  torch.manual_seed(seed);  np.random.seed(seed)
+
+batch_size           = 1000
+lr                   = 0.1
+outer_momentum       = 0.9
+inner_momentum       = 0.0
+noise_mult           = 0.0          # no DP noise in this script
+delta                = 1e-5
+num_epochs           = 10            # ← raise above warm_start_epochs for real runs
+M                    = 0             # momentum dictionary capacity
+self_aug_factor      = 1
+
+# --- Projection experiment knobs --------------------------------------------
+warm_start_epochs     = 2           # plain-SGD epochs before any projection
+proj_lr_multiplier    = 3.0         # bump LR when projection begins
+scale_pprime_to_pL2   = True       # re-norm p′ so ‖p′‖₂ = ‖p‖₂
+trust_mix_alpha       = 1           # 0→raw p ; 1→pure p′
+rebuild_basis_every   = 3           # epochs; 0→never rebuild
+# -----------------------------------------------------------------------------
+
+
+# -- Virtual-sample parameters --
+subsets_per_class      = 25
+subset_size            = 200
+virtual_augment_factor = 10
+
+# -- “No-clipping” setup (huge C so clipping never triggers)
+c_start = 1e9;  c_end = 1e9
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+###############################################################################
+# 0.1 Memory helper
+###############################################################################
+def print_memory_usage(msg=""):
+    try:
+        mem_mb = psutil.Process(os.getpid()).memory_info().rss / 1024**2
+        print(f"[MEM] {msg} → {mem_mb:,.1f} MB")
+    except Exception:
+        pass
+
+###############################################################################
+# 1. Dataset
+###############################################################################
+mean, std = [0.4914,0.4822,0.4466], [0.2470,0.2435,0.2616]  # tiny typo fix
+train_tf = transforms.Compose([
+    transforms.RandomCrop(32, padding=4),
+    transforms.RandomHorizontalFlip(),
+    transforms.ToTensor(),
+    transforms.RandomErasing(p=0.5, scale=(0.02,0.2)),
+    transforms.Normalize(mean, std),
+])
+test_tf = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize(mean,std)
+])
+
+train_ds = datasets.CIFAR10(root="./data", train=True , download=True, transform=train_tf)
+test_ds  = datasets.CIFAR10(root="./data", train=False, download=True, transform=test_tf)
+
+class IndexedSubset(Subset):
+    """Return (x, y, idx) for momentum tracking."""
+    def __getitem__(self, idx):
+        x, y = super().__getitem__(idx)
+        return x, y, idx
+
+n = len(train_ds)
+train_sub  = IndexedSubset(train_ds, range(n))
+train_full = ConcatDataset([train_sub]*self_aug_factor)
+
+train_loader = DataLoader(train_full,batch_size=batch_size,shuffle=True,drop_last=True)
+test_loader  = DataLoader(test_ds ,batch_size=batch_size,shuffle=False)
+
+###############################################################################
+# 2. ResNet-20 (GroupNorm)
+###############################################################################
+class BasicBlock(nn.Module):
+    def __init__(self,in_planes,planes,stride=1):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_planes,planes,3,stride,1,bias=False)
+        self.gn1   = nn.GroupNorm(8,planes)
+        self.conv2 = nn.Conv2d(planes,planes,3,1,1,bias=False)
+        self.gn2   = nn.GroupNorm(8,planes)
+        self.short = nn.Sequential()
+        if stride!=1 or in_planes!=planes:
+            self.short = nn.Sequential(
+                nn.Conv2d(in_planes,planes,1,stride,bias=False),
+                nn.GroupNorm(8,planes)
+            )
+    def forward(self,x):
+        out = F.relu(self.gn1(self.conv1(x)))
+        out = self.gn2(self.conv2(out))
+        out = out + self.short(x)
+        return F.relu(out)
+
+class ResNet20(nn.Module):
+    def __init__(self,num_classes=10):
+        super().__init__()
+        self.in_planes = 16
+        self.conv1 = nn.Conv2d(3,16,3,1,1,bias=False)
+        self.gn1   = nn.GroupNorm(8,16)
+        self.layer1 = self._make_layer(16,3,1)
+        self.layer2 = self._make_layer(32,3,2)
+        self.layer3 = self._make_layer(64,3,2)
+        self.avgpool = nn.AdaptiveAvgPool2d(1)
+        self.fc      = nn.Linear(64,num_classes)
+    def _make_layer(self,planes,blocks,stride):
+        strides=[stride]+[1]*(blocks-1); layers=[]
+        for s in strides:
+            layers.append(BasicBlock(self.in_planes,planes,s))
+            self.in_planes = planes
+        return nn.Sequential(*layers)
+    def forward(self,x):
+        x = F.relu(self.gn1(self.conv1(x)))
+        x = self.layer1(x); x=self.layer2(x); x=self.layer3(x)
+        x = self.avgpool(x); x=torch.flatten(x,1)
+        return self.fc(x)
+
+def evaluate(model,loader):
+    was_training = model.training
+    model.eval(); correct=total=0
+    with torch.no_grad():
+        for X,y in loader:
+            X,y = X.to(device), y.to(device)
+            preds = model(X).argmax(1)
+            correct += (preds==y).sum().item(); total += y.size(0)
+    if was_training: model.train()
+    return 100.*correct/total
+
+###############################################################################
+# 3. Build DP-ready network
+###############################################################################
+def build_model():
+    net = ResNet20().to(device)
+    if ModuleValidator.validate(net,strict=False):
+        net = ModuleValidator.fix(net).to(device)
+    return GradSampleModule(net)
+
+###############################################################################
+# 4. LRU-momentum dict
+###############################################################################
+class LRUOrderedDict(OrderedDict):
+    def __init__(self,*a,maxsize=10_000,**kw): self.maxsize=maxsize; super().__init__(*a,**kw)
+    def __getitem__(self,key):
+        val=super().__getitem__(key); self.move_to_end(key); return val
+    def __setitem__(self,key,val):
+        if key in self: self.move_to_end(key)
+        super().__setitem__(key,val)
+        if len(self)>self.maxsize: self.popitem(last=False)
+
+momentum_dict = LRUOrderedDict(maxsize=M)
+
+###############################################################################
+# 5. Per-sample momentum vector
+###############################################################################
+def compute_inner_momentum_grads_idxed(dp_model,X,y,idxs):
+    dp_model.zero_grad()
+    loss = F.cross_entropy(dp_model(X),y); loss.backward()
+    bs = X.size(0); param_vecs=[None]*bs
+    for p in dp_model.parameters():
+        gs = getattr(p,"grad_sample",None)
+        if gs is None: continue
+        gs_flat = gs.view(bs,-1).detach()
+        for i in range(bs):
+            param_vecs[i] = gs_flat[i] if param_vecs[i] is None \
+                            else torch.cat([param_vecs[i],gs_flat[i]],0)
+        p.grad_sample=None
+    sample_to_vecs={}
+    for i in range(bs):
+        sid = int(idxs[i]); sample_to_vecs.setdefault(sid,[]).append(param_vecs[i].to(device))
+    batch_v=[]
+    for sid,vecs in sample_to_vecs.items():
+        g_i = torch.stack(vecs,0).mean(0)
+        old_v = momentum_dict[sid].to(device) if sid in momentum_dict \
+                 else torch.zeros_like(g_i)
+        new_v = inner_momentum*old_v + (1-inner_momentum)*g_i
+        momentum_dict[sid] = new_v.half().cpu();  batch_v.append(new_v)
+    return batch_v, len(sample_to_vecs)
+
+###############################################################################
+# 6. Outer step (no clipping/no noise)
+###############################################################################
+def outer_step_noDP(dp_model,optimizer,batch_v):
+    grad_sum = torch.stack(batch_v,0).sum(0)
+    final_grad = grad_sum/len(batch_v)
+    idx=0
+    for p in dp_model.parameters():
+        numel=p.numel(); p.grad=final_grad[idx:idx+numel].view_as(p); idx+=numel
+    optimizer.step()
+
+###############################################################################
+# 7. Virtual subsets helpers
+###############################################################################
+def build_virtual_subsets(dataset,subsets_per_class,subset_size,augment_factor):
+    cls_idx=[[] for _ in range(10)]
+    for i in range(len(dataset)): _,c=dataset[i]; cls_idx[c].append(i)
+    v_subsets=[]
+    for c in range(10):
+        random.shuffle(cls_idx[c])
+        for k in range(subsets_per_class):
+            subset=cls_idx[c][k*subset_size:(k+1)*subset_size]
+            for _ in range(augment_factor): v_subsets.append((subset,c))
+    return v_subsets
+
+def compute_fullmodel_grad_for_subset(model,subset_idxs,dataset):
+    model.zero_grad()
+    X=torch.stack([dataset[i][0] for i in subset_idxs]).to(device)
+    y=torch.tensor([dataset[i][1] for i in subset_idxs],device=device)
+    loss = F.cross_entropy(model(X),y); loss.backward()
+    parts=[p.grad.view(-1).detach() for p in model.parameters() if p.grad is not None]
+    return torch.cat(parts).to(device)/len(subset_idxs)
+
+###############################################################################
+# 8. Gram–Schmidt
+###############################################################################
+def gram_schmidt(vecs,eps=1e-10):
+    basis=[]
+    for v in vecs:
+        w=v.clone().float().to(device)
+        for b in basis: w -= torch.dot(w,b)*b
+        n=w.norm()
+        if n>eps: basis.append(w/n)
+    return basis
+
+def build_e_basis_for(model):
+    """Compute Gram–Schmidt-orthonormalised gradients of all virtual subsets
+       using the *current* model parameters."""
+    v_subsets = build_virtual_subsets(
+        train_ds,
+        subsets_per_class,
+        subset_size,
+        virtual_augment_factor,
+    )
+    e_list = [
+        compute_fullmodel_grad_for_subset(model, idxs, train_ds)
+        for idxs, _ in v_subsets
+    ]
+    return gram_schmidt(e_list)
+
+###############################################################################
+# 9. Unwrapped population grad
+###############################################################################
+def compute_population_grad_unwrapped(dp_model,X,y):
+    net = dp_model._module
+    net.zero_grad()
+    F.cross_entropy(net(X),y).backward()
+    parts=[p.grad.view(-1).detach() for p in net.parameters() if p.grad is not None]
+    return torch.cat(parts).to(device) / X.size(0)
+
+###############################################################################
+# 10-A. Training loop
+###############################################################################
+def run_training(dp_net,
+                 optimizer,
+                 want_projection,
+                 e_basis,
+                 project,
+                 train_loader,
+                 test_loader,
+                 diag_every:int=50):
+
+    epoch_losses, epoch_accs = [], []
+    scheduler = optim.lr_scheduler.MultiStepLR(optimizer, milestones=[], gamma=0.1)
+    momentum_dict.clear()
+
+    # <<< NEW -----------------------------------------------------------------
+    # Local trackers to diagnose the projection run as well
+    local_diff_L2, local_cos = [], []
+    # -------------------------------------------------------------------------
+
+    for epoch in range(1, num_epochs + 1):
+        dp_net.train()
+        losses, recent_losses = [], []
+        epoch_start = time.time()
+
+        # ---- experiment-level toggles -------------------------------------
+        use_proj_this_epoch = want_projection and (epoch > warm_start_epochs)
+
+        # (new) after warm-start, rebuild ONCE so the basis matches current weights
+        if epoch == warm_start_epochs and want_projection:
+            e_basis[:] = build_e_basis_for(dp_net._module)
+
+        # optional periodic refresh
+        if rebuild_basis_every and (epoch % rebuild_basis_every == 0):
+            e_basis[:] = build_e_basis_for(dp_net._module)
+
+        if epoch == warm_start_epochs + 1 and proj_lr_multiplier != 1.0 and want_projection:
+            for pg in optimizer.param_groups:
+                pg["lr"] *= proj_lr_multiplier
+        if rebuild_basis_every and (epoch % rebuild_basis_every == 0):
+            e_basis[:] = gram_schmidt(e_basis)  # quick refresh
+        # -------------------------------------------------------------------
+
+        total_batches = len(train_loader)
+        for batch_idx, (X, y, idxs) in enumerate(train_loader, 1):
+            X, y = X.to(device), y.to(device)
+
+            # ---- forward / backward ---------------------------------------
+            batch_v, _ = compute_inner_momentum_grads_idxed(dp_net, X, y, idxs)
+            p          = compute_population_grad_unwrapped(dp_net, X, y)
+            p_prime    = project(p, e_basis)
+
+            # <<< NEW: dimensionality guard ---------------------------------
+            assert p_prime.shape == p.shape, \
+                f"[Bug] p′ dim {p_prime.shape} ≠ p dim {p.shape}"
+            # ----------------------------------------------------------------
+
+            if scale_pprime_to_pL2 and p_prime.norm() > 0:
+                p_prime = p_prime * (p.norm() / p_prime.norm())
+
+            g_update  = trust_mix_alpha * p_prime + (1 - trust_mix_alpha) * p
+            # ----------------------------------------------------------------
+
+            # choose update direction ---------------------------------------
+            if use_proj_this_epoch:
+                idx = 0
+                for p_param in dp_net.parameters():
+                    n = p_param.numel()
+                    p_param.grad = g_update[idx: idx + n].view_as(p_param)
+                    idx += n
+                optimizer.step()
+            else:
+                outer_step_noDP(dp_net, optimizer, batch_v)
+            # ----------------------------------------------------------------
+
+            # <<< NEW: on-the-fly projection diagnostics (always on) --------
+            with torch.no_grad():
+                diff = (p - p_prime).norm().item()
+                cos  = torch.dot(p, p_prime).item() / (
+                       p.norm().item() * p_prime.norm().item() + 1e-12)
+                local_diff_L2.append(diff)
+                local_cos.append(cos)
+            # ----------------------------------------------------------------
+
+            # diagnostics (loss etc.) ---------------------------------------
+            with torch.no_grad():
+                batch_loss = F.cross_entropy(dp_net(X), y).item()
+            losses.append(batch_loss)
+            recent_losses.append(batch_loss)
+            if len(recent_losses) > 10:
+                recent_losses.pop(0)
+
+            if batch_idx % diag_every == 0 or batch_idx == total_batches:
+                secs_per_batch = (time.time() - epoch_start) / batch_idx
+                tag = "ProjSGD" if use_proj_this_epoch else "SGD"
+                fmt = (f"[{tag}] Epoch {epoch}/{num_epochs}  "
+                       f"Batch {batch_idx:>4}/{total_batches}  "
+                       f"η≈{secs_per_batch:.2f}s  "
+                       f"run-loss={statistics.mean(recent_losses):.4f}  "
+                       f"‖p-p′‖₂={diff:.4f}  cos={cos:.4f}")
+                print_memory_usage(fmt)
+        # -------------------------------------------------------------------
+        scheduler.step()
+        epoch_losses.append(np.mean(losses))
+        epoch_accs.append(evaluate(dp_net, test_loader))
+
+        minutes = (time.time() - epoch_start) / 60
+        tag = "ProjSGD" if use_proj_this_epoch else "SGD"
+        print(f"[{tag}] Epoch {epoch} done  "
+              f"loss={epoch_losses[-1]:.3f}  "
+              f"acc={epoch_accs[-1]:.2f}%  "
+              f"({minutes:.1f} min)\n")
+
+    # <<< NEW: return extra diagnostics -------------------------------------
+    return {"loss": epoch_losses,
+            "acc": epoch_accs,
+            "diff_L2": local_diff_L2,
+            "cos": local_cos}
+    # -----------------------------------------------------------------------
+
+###############################################################################
+# 10-B. main_run
+###############################################################################
+def main_run():
+    print_memory_usage("Start")
+
+    # A) build virtual subsets
+    v_subsets = build_virtual_subsets(train_ds,subsets_per_class,subset_size,
+                                      virtual_augment_factor)
+    print(f"Built {len(v_subsets)} virtual subsets.")
+
+    # B) compute e_i for every virtual subset
+    base_net = ResNet20().to(device).eval()
+    e_list = [compute_fullmodel_grad_for_subset(base_net,idxs,train_ds)
+              for idxs,_ in v_subsets]
+    e_basis = gram_schmidt(e_list)
+    print(f"Orthonormal basis size = {len(e_basis)}/{len(e_list)}")
+
+    def project_onto(vec,basis):
+        out=torch.zeros_like(vec)
+        for b in basis: out += torch.dot(vec,b)*b
+        return out
+
+
+    # ProjSGD (after warm-start)
+    dp_proj = build_model().to(device)
+    opt_proj = optim.SGD(dp_proj.parameters(),lr=lr,momentum=outer_momentum,
+                         weight_decay=5e-4)
+    proj_stats = run_training(dp_proj,opt_proj,True,
+                               e_basis,project_onto,
+                               train_loader,test_loader)
+
+    ##################################################################
+    # Visualisations
+    ##################################################################
+    epochs = range(1,num_epochs+1)
+    steps  = range(1,len(proj_stats['diff_L2'])+1)  # <<< NEW
+
+    # 0) SGD-vs-ProjSGD curves
+    plt.figure(figsize=(11,4))
+    plt.subplot(1,2,1)
+    #plt.plot(epochs,base_stats['loss'],'-o',label='SGD (p)')
+    plt.plot(epochs,proj_stats['loss'],'-o',label='ProjSGD (p′)')
+    plt.title("Training Loss per Epoch"); plt.xlabel("Epoch"); plt.ylabel("Loss"); plt.legend()
+    plt.subplot(1,2,2)
+    #plt.plot(epochs,base_stats['acc'],'-o',label='SGD (p)')
+    plt.plot(epochs,proj_stats['acc'],'-o',label='ProjSGD (p′)')
+    plt.title("Test Accuracy per Epoch"); plt.xlabel("Epoch"); plt.ylabel("Accuracy (%)"); plt.legend()
+    plt.tight_layout(); plt.show()
+
+    # <<< NEW: projection diagnostics ---------------------------------------
+    plt.figure(figsize=(10,4))
+    plt.subplot(1,2,1)
+    plt.plot(steps,proj_stats['diff_L2'],color='red')
+    plt.title("‖p − p′‖₂ over Steps (Proj run)")
+    plt.xlabel("Training Step"); plt.ylabel("L2 Norm")
+    plt.subplot(1,2,2)
+    plt.plot(steps,proj_stats['cos'],color='orange')
+    plt.title("Cosine Similarity(p, p′) (Proj run)")
+    plt.xlabel("Training Step"); plt.ylabel("Cosine")
+    plt.tight_layout(); plt.show()
+    # ----------------------------------------------------------------------
+
+    # Quick stats
+    print("\nPopulation-level stats (Proj run):")
+    print(f"  mean‖p − p′‖₂ = {np.mean(proj_stats['diff_L2']):.4f}")
+    print(f"  mean cos(p,p′) = {np.mean(proj_stats['cos']):.4f}")
+
+    print("\nFinal accuracy:")
+    #print(f"  SGD (p)   : {base_stats['acc'][-1]:.2f}%")
+    print(f"  ProjSGD p′: {proj_stats['acc'][-1]:.2f}%")
+
+###############################################################################
+if __name__ == "__main__":
+    main_run()
+

--- a/local_dpsgd_experiment.py
+++ b/local_dpsgd_experiment.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+# ===============================================================
+#  Unified DP vision benchmark – CIFAR‑10 (private) + synthetic (public)
+#  ✦ PUBLIC_METHOD ∈ {"add", "mixsub"} controls how public gradients are used
+#  (2025-07-10 bug-fixed & instrumented edition)
+# ===============================================================
+
+import os, random, warnings, time
+from itertools import cycle
+from collections import defaultdict
+import sys, torch, matplotlib.pyplot as plt
+from torchvision.utils import make_grid
+
+import numpy as np
+import matplotlib.pyplot as plt
+import torch, torch.nn as nn, torch.nn.functional as F
+from torch import optim
+from torch.utils.data import DataLoader, Subset, ConcatDataset
+from torchvision import datasets, transforms
+from opacus.validators import ModuleValidator
+from opacus.accountants import RDPAccountant
+from opacus.grad_sample import GradSampleModule
+from diffusers import ConsistencyModelPipeline            # light decoder
+import torchvision.transforms as T
+
+warnings.filterwarnings("ignore", category=UserWarning)
+
+# ------------------------------------------------------------------
+# 0.  Flags & debug knob
+# ------------------------------------------------------------------
+EXPERIMENT      = os.getenv("EXPERIMENT", "central_priv")
+PUBLIC_METHOD   = os.getenv("PUBLIC_METHOD", "mixsub").lower()     # add | mixsub
+DEBUG           = bool(int(os.getenv("DEBUG", "1")))               # 0 = silent
+FIXED_PUB = bool(int(os.getenv("FIXED_PUB", "0")))  # set 0 to keep dynamic
+
+assert PUBLIC_METHOD in {"add", "mixsub"}, "PUBLIC_METHOD must be add|mixsub"
+
+# ------------------------------------------------------------------
+# 1.  Hyper-parameters
+# ------------------------------------------------------------------
+SEED, PRIV_BATCH, PUB_BATCH = 0, 512, 500
+NUM_EPOCHS, HEARTBEAT       = 5, 1
+
+K_LOCAL, ETA_LOCAL          = 3, 0.025
+
+# ---- learning-rates -----------------------------------------------------------
+LR_OUTER, MOMENTUM_OUTER    = 0.05, 0.9          # used by *central* DP-SGD
+OUTER_LR_LOCAL              = float(os.getenv("OUTER_LR_LOCAL", "1.0"))
+OUTER_LR_SCAFFOLD           = float(os.getenv("OUTER_LR_SCAFFOLD", "1.0"))
+
+# ---- clipping / noise ---------------------------------------------------------
+C_CLIP_PRIV                 = 1.0                                      # private
+C_CLIP_PUB                  = float(os.getenv("C_CLIP_PUB", "1.0"))    # public
+NOISE_MULT                  = 1.0
+DELTA                       = 1e-5
+
+MILESTONES, GAMMA           = [10, 13], 0.1
+DATA_FRACTION, SELF_AUG_FACTOR = 0.2, 1
+DEVICE                      = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+α_SCALE = PUB_BATCH / (PRIV_BATCH + PUB_BATCH)   # factor for mix-subtract
+
+# ------------------------------------------------------------------
+# 2.  RNG
+# ------------------------------------------------------------------
+torch.manual_seed(SEED); random.seed(SEED); np.random.seed(SEED)
+
+# ------------------------------------------------------------------
+# 3.  CIFAR-10  (⇐ no RandomErasing)
+# ------------------------------------------------------------------
+mean, std = [0.4914, 0.4822, 0.4465], [0.2470, 0.2435, 0.2616]
+
+train_tf = transforms.Compose([
+    transforms.Resize(32),
+    transforms.RandomCrop(32, padding=4),
+    transforms.RandomHorizontalFlip(),
+    transforms.ToTensor(),
+    transforms.Normalize(mean, std)
+])
+
+test_tf = transforms.Compose([
+    transforms.Resize(32),
+    transforms.ToTensor(),
+    transforms.Normalize(mean, std)
+])
+
+cifar_train = datasets.CIFAR10("./data", train=True, download=True, transform=train_tf)
+num_priv    = int(len(cifar_train) * DATA_FRACTION)
+priv_idx    = np.random.choice(len(cifar_train), num_priv, replace=False)
+priv_base   = Subset(cifar_train, priv_idx)
+
+class IdxSubset(Subset):
+    def __getitem__(self, i):
+        x, y = super().__getitem__(i)
+        return x, y, i
+
+private_set = ConcatDataset([IdxSubset(priv_base, range(num_priv))] * SELF_AUG_FACTOR)
+N_PRIVATE   = len(private_set)
+train_priv  = DataLoader(private_set, PRIV_BATCH, shuffle=True,
+                         num_workers=2, pin_memory=True)
+
+# ------------------------------------------------------------------
+# 4.  Synthetic image generator  (Consistency-Decoder ImageNet-64)
+# ------------------------------------------------------------------
+_IMAGENET_MAP = {0: 404, 1: 817, 2: 14, 3: 281, 4: 354,
+                 5: 207, 6: 30, 7: 339, 8: 510, 9: 555}
+
+def build_pipe():
+    pipe = ConsistencyModelPipeline.from_pretrained(
+        "openai/diffusers-cd_imagenet64_l2",
+        torch_dtype=torch.float16
+    ).to(DEVICE)
+    pipe.set_progress_bar_config(disable=True)
+    return pipe
+
+class DiffusionBuffer:
+    """
+    On-the-fly synthetic CIFAR-sized images produced by Consistency Decoding.
+    Guarantees that __next__ always returns exactly `bs` images.
+    """
+    def __init__(self, bs=PUB_BATCH, pool=128, steps=1, mb=16):
+        self.bs     = bs
+        self.pool   = max(pool, bs)          # <- ensure queue ≥ batch size
+        self.steps  = steps
+        self.mb     = mb
+        self.pipe   = build_pipe()
+        self.img_q  = torch.empty(0, 3, 32, 32)
+        self.lab_q  = torch.empty(0, dtype=torch.long)
+        self.resize = T.Resize(32, T.InterpolationMode.BICUBIC, antialias=True)
+        self._refill()
+
+    @torch.no_grad()
+    def _refill(self):
+        need = max(self.pool, self.bs) - self.img_q.size(0)
+        if need <= 0:
+            return                            # already have enough
+        labels = torch.randint(0, 10, (need,))
+        imgs   = []
+        for i in range(0, need, self.mb):
+            cls_ids = torch.tensor([_IMAGENET_MAP[int(c)]
+                                    for c in labels[i:i + self.mb]], device=DEVICE)
+            pil = self.pipe(batch_size=cls_ids.numel(),
+                            class_labels=cls_ids,
+                            num_inference_steps=self.steps).images
+            imgs.extend(pil)
+
+        # ---- defend against empty returns ------------------------------------
+        if not imgs:
+            raise RuntimeError("Diffusion pipeline returned 0 images. "
+                               "Try reducing PUB_BATCH or check GPU memory.")
+
+        tens = torch.stack([train_tf(self.resize(p)) for p in imgs])
+        self.img_q = torch.cat([self.img_q, tens.cpu()])
+        self.lab_q = torch.cat([self.lab_q, labels])
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        while self.img_q.size(0) < self.bs:   # keep refilling until enough
+            self._refill()
+        X, y = self.img_q[:self.bs], self.lab_q[:self.bs]
+        self.img_q, self.lab_q = self.img_q[self.bs:], self.lab_q[self.bs:]
+        return X.to(DEVICE), y.to(DEVICE)
+
+
+train_pub = DiffusionBuffer()
+# ------------------------------------------------------------------
+# optional: use a *fixed* synthetic mini-batch (control-variate style)
+# ------------------------------------------------------------------
+
+if FIXED_PUB:
+    print("[INFO] Using a single static public batch for every iteration")
+    _X_fixed, _y_fixed = next(train_pub)             # grab once at start
+
+    def _fixed_loader():
+        while True:                                 # endless generator
+            yield _X_fixed, _y_fixed
+
+    get_pub_iter = lambda: _fixed_loader()          # returns generator
+else:
+    from itertools import cycle
+    get_pub_iter = lambda: cycle(train_pub)         # original behaviour
+
+
+
+# ------------------------------------------------------------------
+# 5.  Test set
+# ------------------------------------------------------------------
+test_set    = datasets.CIFAR10("./data", train=False, download=True, transform=test_tf)
+test_loader = DataLoader(test_set, 512, shuffle=False, num_workers=2, pin_memory=True)
+
+# ------------------------------------------------------------------
+# 6.  ResNet‑20  (GroupNorm+ELU)
+# ------------------------------------------------------------------
+class BasicBlock(nn.Module):
+    expansion = 1
+    def __init__(self, inp, outp, stride=1):
+        super().__init__()
+        self.c1 = nn.Conv2d(inp, outp, 3, stride, 1, bias=False)
+        self.n1 = nn.GroupNorm(8, outp)
+        self.c2 = nn.Conv2d(outp, outp, 3, 1, 1, bias=False)
+        self.n2 = nn.GroupNorm(8, outp)
+        self.sc = nn.Identity() if stride == 1 and inp == outp else \
+                  nn.Sequential(nn.Conv2d(inp, outp, 1, stride, bias=False),
+                                nn.GroupNorm(8, outp))
+    def forward(self, x):
+        out = self.n1(F.elu(self.c1(x)))
+        out = self.n2(F.elu(self.c2(out)))
+        return F.elu(out + self.sc(x))
+
+class ResNet20(nn.Module):
+    def __init__(self, classes=10):
+        super().__init__()
+        self.inp = 16
+        self.c1  = nn.Conv2d(3, 16, 3, 1, 1, bias=False)
+        self.n1  = nn.GroupNorm(8, 16)
+        self.l1  = self._layer(16, 3, 1)
+        self.l2  = self._layer(32, 3, 2)
+        self.l3  = self._layer(64, 3, 2)
+        self.avg = nn.AdaptiveAvgPool2d(1)
+        self.fc  = nn.Linear(64, classes)
+    def _layer(self, ch, blocks, stride):
+        seq = []
+        for s in [stride] + [1] * (blocks - 1):
+            seq.append(BasicBlock(self.inp, ch, s))
+            self.inp = ch
+        return nn.Sequential(*seq)
+    def forward(self, x):
+        x = self.n1(F.elu(self.c1(x)))
+        x = self.l1(x); x = self.l2(x); x = self.l3(x)
+        return self.fc(torch.flatten(self.avg(x), 1))
+
+def build_model():
+    m = ResNet20().to(DEVICE)
+    if ModuleValidator.validate(m, strict=False):
+        m = ModuleValidator.fix(m).to(DEVICE)
+    return m
+
+# ------------------------------------------------------------------
+# 7-A.  Generic helpers
+# ------------------------------------------------------------------
+@torch.no_grad()
+def flat(m): return torch.cat([p.data.view(-1) for p in m.parameters()])
+
+@torch.no_grad()
+def assign(m, vec):
+    i = 0
+    for p in m.parameters():
+        n = p.numel()
+        p.data.copy_(vec[i:i + n].view_as(p))
+        i += n
+
+@torch.no_grad()
+def accuracy(m):
+    m.eval(); tot = 0; cor = 0
+    with torch.no_grad():
+        for X, y in test_loader:
+            X, y = X.to(DEVICE), y.to(DEVICE)
+            cor += (m(X).argmax(1) == y).sum().item()
+            tot += y.size(0)
+    m.train()
+    return 100 * cor / tot
+
+def l1(x): return x.norm(1).item()
+def l2(x): return x.norm(2).item()
+def cosine(a, b):
+    if b is None or b.numel() == 0:
+        return 0.0
+    return F.cosine_similarity(a, b, dim=0, eps=1e-8).item()
+
+def init_log(): return defaultdict(list)
+
+def clip_agg(mat, c, add_noise=True):
+    norms   = mat.norm(2, 1, keepdim=True)
+    clipped = mat * torch.clamp(c / (norms + 1e-6), max=1.)
+    vec     = clipped.mean(0)
+    if add_noise:
+        vec += torch.randn_like(vec) * (NOISE_MULT * c / mat.size(0))
+    return vec, norms.squeeze(), (clipped != mat).any(1)
+
+# ------------------------------------------------------------------
+# 7-A-bis.  Safe live-debug printer
+# ------------------------------------------------------------------
+def dbg(step, Δp, Δq, upd, acc, eps):
+    """
+    Pretty-prints L2 norms, cosine, accuracy & ε every HEARTBEAT steps.
+    Works even if Δq is None (no public data branch).
+    """
+    if not DEBUG or step % HEARTBEAT:
+        return
+    l2_q = l2(Δq) if Δq is not None else 0.0
+    print(f"[{step:4}]  ‖Δp‖₂={l2(Δp):6.3f}  "
+          f"‖Δq‖₂={l2_q:6.3f}  "
+          f"cos={cosine(Δp, Δq):6.3f}  "
+          f"‖upd‖₂={l2(upd):6.3f}  "
+          f"acc={acc:5.2f}%  ε={eps:5.2f}", flush=True)
+
+
+# ------------------------------------------------------------------
+# 7-B.  Baseline logging helper
+# ------------------------------------------------------------------
+@torch.no_grad()
+def log_baseline(model, log, Xp, yp, Xq=None, yq=None):
+    model.eval()
+    loss_p = F.cross_entropy(model(Xp), yp).item()
+    if Xq is not None:
+        loss_q = F.cross_entropy(model(Xq), yq).item()
+        log["loss"].append((loss_p + loss_q) / 2)
+    else:
+        log["loss"].append(loss_p)
+    log["acc"].append(accuracy(model)); log["acc_step"].append(0)
+    for k in ("l1_priv", "l2_priv", "l1_pub", "l2_pub", "cos"):
+        log[k].append(0.0)
+    model.train()
+
+# ------------------------------------------------------------------
+# 7-C.  Plotter (unchanged)
+# ------------------------------------------------------------------
+def plot_curves(log, title_suffix=""):
+    its = list(range(len(log["loss"])))
+    plt.figure()
+    plt.plot(its, log["l1_priv"], label="‖Δ_priv‖₁")
+    if any(log["l1_pub"]): plt.plot(its, log["l1_pub"], label="‖Δ_pub‖₁")
+    plt.title("L1 norms" + title_suffix); plt.xlabel("iteration"); plt.legend(); plt.tight_layout()
+
+    plt.figure()
+    plt.plot(its, log["l2_priv"], label="‖Δ_priv‖₂")
+    if any(log["l2_pub"]): plt.plot(its, log["l2_pub"], label="‖Δ_pub‖₂")
+    plt.title("L2 norms" + title_suffix); plt.xlabel("iteration"); plt.legend(); plt.tight_layout()
+
+    if any(log["cos"]):
+        plt.figure()
+        plt.plot(its, log["cos"])
+        plt.title("Cosine(Δ_priv, Δ_pub)" + title_suffix)
+        plt.xlabel("iteration"); plt.tight_layout()
+
+    plt.figure()
+    plt.plot(its, log["loss"], label="loss", alpha=0.7)
+    if log["acc"]:
+        plt.plot(log["acc_step"], log["acc"], label="accuracy", alpha=0.7)
+    plt.title("Loss / Accuracy" + title_suffix); plt.xlabel("iteration"); plt.legend(); plt.tight_layout()
+    plt.show()
+
+# ------------------------------------------------------------------
+# 8-A. CENTRAL DP-SGD  (minor: use new clip consts for clarity)
+# ------------------------------------------------------------------
+def train_central(use_public: bool):
+    model = GradSampleModule(build_model())
+    opt   = optim.SGD(model.parameters(), lr=LR_OUTER, momentum=MOMENTUM_OUTER)
+    sched = optim.lr_scheduler.MultiStepLR(opt, MILESTONES, GAMMA)
+    accnt, sr = RDPAccountant(), PRIV_BATCH / N_PRIVATE
+    pub_iter = get_pub_iter() if use_public else None
+
+    log, step, total = init_log(), 0, NUM_EPOCHS * len(train_priv)
+    log["acc_step"] = []
+
+    # ---- baseline -------------------------------------------------------------
+    X0p, y0p, _ = next(iter(train_priv)); X0p, y0p = X0p.to(DEVICE), y0p.to(DEVICE)
+    if use_public:
+        X0q, y0q = next(iter(train_pub))
+    else:
+        X0q = y0q = None
+    log_baseline(model, log, X0p, y0p, X0q, y0q)
+
+    for epoch in range(NUM_EPOCHS):
+        for Xp, yp, _ in train_priv:
+            step += 1
+            Xp, yp = Xp.to(DEVICE), yp.to(DEVICE)
+
+            # ---- PRIVATE pass --------------------------------------------------
+            opt.zero_grad(set_to_none=True)
+            loss = F.cross_entropy(model(Xp), yp)
+            loss.backward()
+            log["loss"].append(loss.item())
+
+            priv_norms = []
+            for p in model.parameters():
+                priv_norms.append(p.grad_sample.pow(2).flatten(1).sum(1))
+            priv_norms = torch.stack(priv_norms).sum(0).sqrt()
+            scale = (C_CLIP_PRIV / (priv_norms + 1e-6)).clamp(max=1.)
+            for p in model.parameters():
+                p.grad = (p.grad_sample * scale.view(-1, *([1] * (p.grad_sample.dim() - 1)))).sum(0)
+                p.grad /= PRIV_BATCH
+                p.grad += torch.randn_like(p.grad) * (NOISE_MULT * C_CLIP_PRIV / PRIV_BATCH)
+                p.grad_sample = None
+            delta_priv = torch.cat([p.grad.flatten() for p in model.parameters()])
+            log["l1_priv"].append(l1(delta_priv)); log["l2_priv"].append(l2(delta_priv))
+
+            if use_public:
+                # ---- PUBLIC pass ----------------------------------------------
+                opt.zero_grad(set_to_none=True)
+                Xq, yq = next(pub_iter)
+                F.cross_entropy(model(Xq), yq).backward()
+
+                pub_norms = []
+                for p in model.parameters():
+                    pub_norms.append(p.grad_sample.pow(2).flatten(1).sum(1))
+                pub_norms = torch.stack(pub_norms).sum(0).sqrt()
+                scale_pub = (C_CLIP_PUB / (pub_norms + 1e-6)).clamp(max=1.)
+                for p in model.parameters():
+                    p.grad = (p.grad_sample *
+                              scale_pub.view(-1, *([1] * (p.grad_sample.dim() - 1)))).sum(0)
+                    p.grad /= PUB_BATCH
+                    p.grad_sample = None
+                delta_pub = torch.cat([p.grad.flatten() for p in model.parameters()])
+                log["l1_pub"].append(l1(delta_pub)); log["l2_pub"].append(l2(delta_pub))
+                log["cos"].append(cosine(delta_priv, delta_pub))
+            else:
+                delta_pub = torch.zeros_like(delta_priv)
+                log["l1_pub"].append(0.0); log["l2_pub"].append(0.0); log["cos"].append(0.0)
+
+            # ---- Combine -------------------------------------------------------
+            if   not use_public:          update = delta_priv
+            elif PUBLIC_METHOD == "add":  update = delta_priv + delta_pub
+            else:                         update = delta_priv - α_SCALE * delta_pub
+
+            with torch.no_grad():
+                splits = torch.split(update, [p.numel() for p in model.parameters()])
+                for p, u in zip(model.parameters(), splits):
+                    p.grad = u.view_as(p)
+            opt.step()
+            accnt.step(noise_multiplier=NOISE_MULT, sample_rate=sr)
+
+            if step % HEARTBEAT == 0:
+                acc = accuracy(model)
+                log["acc"].append(acc); log["acc_step"].append(step)
+                print(f"[{step:>4}/{total}] loss={loss.item():.3f} "
+                      f"acc={acc:5.2f}%  ε={accnt.get_epsilon(DELTA):.2f}")
+
+        sched.step()
+    summary(model, accnt, log, "central_" + ("pub" if use_public else "priv"))
+
+# ------------------------------------------------------------------
+# 8-B. Helper for LOCAL DP-SGD
+# ------------------------------------------------------------------
+def local_updates(global_model, X, y):
+    base = flat(global_model).clone()
+    deltas = []
+    for j in range(X.size(0)):
+        local = build_model(); assign(local, base)
+        opt = optim.SGD(local.parameters(), lr=ETA_LOCAL)
+        for _ in range(K_LOCAL):
+            opt.zero_grad(set_to_none=True)
+            F.cross_entropy(local(X[j:j + 1]), y[j:j + 1]).backward()
+            opt.step()
+        deltas.append(flat(local) - base)
+        del local
+    return torch.stack(deltas, 0)    # shape: [|X|, |θ|]
+
+# ------------------------------------------------------------------
+# 8-B.  LOCAL DP-SGD  (fixed & instrumented)
+# ------------------------------------------------------------------
+def train_local(use_public: bool):
+    model = build_model()
+
+    dummy_sched = optim.lr_scheduler.MultiStepLR(
+        optim.SGD(model.parameters(), lr=0.01), MILESTONES, GAMMA
+    )
+
+    accnt, sr   = RDPAccountant(), PRIV_BATCH / N_PRIVATE
+    pub_iter = get_pub_iter() if use_public else None
+
+    log, step   = init_log(), 0
+    total       = NUM_EPOCHS * len(train_priv)
+    log["acc_step"] = []
+
+    # ---- baseline -------------------------------------------------------------
+    X0p, y0p, _ = next(iter(train_priv)); X0p, y0p = X0p.to(DEVICE), y0p.to(DEVICE)
+    if use_public:
+        X0q, y0q = next(iter(train_pub))
+    else:
+        X0q = y0q = None
+    log_baseline(model, log, X0p, y0p, X0q, y0q)
+
+    for epoch in range(NUM_EPOCHS):
+        for Xp, yp, _ in train_priv:
+            step += 1
+            Xp, yp = Xp.to(DEVICE), yp.to(DEVICE)
+            n_priv = Xp.size(0)
+
+            if use_public:
+                Xq, yq = next(pub_iter); Xq, yq = Xq.to(DEVICE), yq.to(DEVICE)
+                X = torch.cat([Xp, Xq]); y = torch.cat([yp, yq])
+            else:
+                X, y = Xp, yp
+
+            # ---- local client updates (no clip/noise yet) ----------------------
+            deltas = local_updates(model, X, y)
+
+            if use_public:
+                delta_priv, delta_pub = deltas[:n_priv], deltas[n_priv:]
+            else:
+                delta_priv, delta_pub = deltas, None
+
+            Δp_bar, _, _ = clip_agg(delta_priv, C_CLIP_PRIV, add_noise=True)
+            if delta_pub is not None and delta_pub.numel():
+                Δq_bar, _, _ = clip_agg(delta_pub, C_CLIP_PUB, add_noise=False)
+            else:
+                Δq_bar = torch.zeros_like(Δp_bar)
+
+            # ---- mix private & public -----------------------------------------
+            if   not use_public:          update = Δp_bar
+            elif PUBLIC_METHOD == "add":  update = Δp_bar + Δq_bar
+            else:                         update = Δp_bar - α_SCALE * Δq_bar
+
+            # ---- outer update (no extra shrink) -------------------------------
+            assign(model, flat(model) + OUTER_LR_LOCAL * update.to(DEVICE))
+
+            # ---- bookkeeping & debug ------------------------------------------
+            log["l1_priv"].append(l1(Δp_bar)); log["l2_priv"].append(l2(Δp_bar))
+            log["l1_pub"].append(l1(Δq_bar));  log["l2_pub"].append(l2(Δq_bar))
+            log["cos"].append(cosine(Δp_bar, Δq_bar) if use_public else 0.0)
+            log["loss"].append(F.cross_entropy(model(Xp), yp).item())
+            accnt.step(noise_multiplier=NOISE_MULT, sample_rate=sr)
+
+            if step % HEARTBEAT == 0:
+                acc = accuracy(model)
+                log["acc"].append(acc); log["acc_step"].append(step)
+                dbg(step, Δp_bar, Δq_bar if use_public else None,
+                    update, acc, accnt.get_epsilon(DELTA))
+
+        dummy_sched.step()
+
+    summary(model, accnt, log, "local_" + ("pub" if use_public else "priv"))
+
+# ------------------------------------------------------------------
+# 8-C. DP-SCAFFOLD
+# ------------------------------------------------------------------
+class DPScaffold:
+    def __init__(self, model):
+        self.vg = torch.zeros_like(flat(model), device=DEVICE)
+        self.vc = {c: torch.zeros_like(flat(model), device=DEVICE) for c in range(10)}
+
+    def local_step(self, model, X, y):
+        base = flat(model).clone()
+        outs = []
+        for j in range(X.size(0)):
+            loc = build_model(); assign(loc, base)
+            opt = optim.SGD(loc.parameters(), lr=ETA_LOCAL)
+            vc  = self.vc[int(y[j])]
+            for _ in range(K_LOCAL):
+                opt.zero_grad(set_to_none=True)
+                preds = loc(X[j:j + 1])
+                loss  = F.cross_entropy(preds, y[j:j + 1])
+                grads = torch.autograd.grad(loss, loc.parameters())
+                gvec  = torch.cat([g.view(-1) for g in grads])
+                gvec  = gvec - vc.detach() + self.vg.detach()
+                with torch.no_grad():
+                    assign(loc, flat(loc) - ETA_LOCAL * gvec)
+            outs.append(flat(loc) - base); del loc
+        return torch.stack(outs, 0)
+
+    def update_control(self, δ, y):
+        for c in range(10):
+            m = (y.cpu() == c)
+            if m.any():
+                self.vc[c] = self.vc[c] - self.vg + δ[m].mean(0) / (K_LOCAL * ETA_LOCAL)
+        self.vg = self.vg * (1 - PRIV_BATCH / N_PRIVATE) + δ.mean(0) / (K_LOCAL * ETA_LOCAL)
+
+# ------------------------------------------------------------------
+# 8-C.  DP-SCAFFOLD (fixed & instrumented)
+# ------------------------------------------------------------------
+def train_scaffold(use_public: bool):
+    model = build_model()
+    scaf  = DPScaffold(model)
+
+    dummy_opt = optim.SGD(model.parameters(), lr=1.0)   # LR unused
+    sched     = optim.lr_scheduler.MultiStepLR(dummy_opt, MILESTONES, GAMMA)
+
+    accnt, sr = RDPAccountant(), PRIV_BATCH / N_PRIVATE
+    pub_iter = get_pub_iter() if use_public else None
+
+    log, step = init_log(), 0
+    total     = NUM_EPOCHS * len(train_priv)
+    log["acc_step"] = []
+
+    # ---- baseline -------------------------------------------------------------
+    X0p, y0p, _ = next(iter(train_priv)); X0p, y0p = X0p.to(DEVICE), y0p.to(DEVICE)
+    if use_public:
+        X0q, y0q = next(iter(train_pub))
+    else:
+        X0q = y0q = None
+    log_baseline(model, log, X0p, y0p, X0q, y0q)
+
+    for epoch in range(NUM_EPOCHS):
+        for Xp, yp, _ in train_priv:
+            step += 1
+            Xp, yp = Xp.to(DEVICE), yp.to(DEVICE)
+            n_priv = Xp.size(0)
+
+            if use_public:
+                Xq, yq = next(pub_iter); Xq, yq = Xq.to(DEVICE), yq.to(DEVICE)
+                X = torch.cat([Xp, Xq]); y = torch.cat([yp, yq])
+            else:
+                X, y = Xp, yp
+
+            # ---- local client updates with control variates --------------------
+            local_tmp = build_model(); assign(local_tmp, flat(model))
+            deltas    = scaf.local_step(local_tmp, X, y)
+            del local_tmp
+
+            δp, δq = (deltas[:n_priv], deltas[n_priv:]) if use_public else (deltas, None)
+
+            Δp_bar, _, _ = clip_agg(δp, C_CLIP_PRIV, add_noise=True)
+            if use_public and δq.numel():
+                Δq_bar, _, _ = clip_agg(δq, C_CLIP_PUB, add_noise=False)
+            else:
+                Δq_bar = torch.zeros_like(Δp_bar)
+
+            # ---- fuse ----------------------------------------------------------
+            if   not use_public:          Δbar = Δp_bar
+            elif PUBLIC_METHOD == "add":  Δbar = Δp_bar + Δq_bar
+            else:                         Δbar = Δp_bar - α_SCALE * Δq_bar
+
+            # ---- global update without extra shrink ---------------------------
+            assign(model, flat(model) + OUTER_LR_SCAFFOLD * Δbar.to(DEVICE))
+
+            # ---- update control variates (private only) ------------------------
+            scaf.update_control(δp.to(DEVICE), yp)
+
+            # ---- bookkeeping & debug ------------------------------------------
+            log["l1_priv"].append(l1(Δp_bar)); log["l2_priv"].append(l2(Δp_bar))
+            log["l1_pub"].append(l1(Δq_bar));  log["l2_pub"].append(l2(Δq_bar))
+            log["cos"].append(cosine(Δp_bar, Δq_bar) if use_public else 0.0)
+            log["loss"].append(F.cross_entropy(model(Xp), yp).item())
+            accnt.step(noise_multiplier=NOISE_MULT, sample_rate=sr)
+
+            if step % HEARTBEAT == 0:
+                acc = accuracy(model)
+                log["acc"].append(acc); log["acc_step"].append(step)
+                dbg(step, Δp_bar, Δq_bar if use_public else None,
+                    Δbar, acc, accnt.get_epsilon(DELTA))
+
+        sched.step()
+
+    summary(model, accnt, log, "scaffold_" + ("pub" if use_public else "priv"))
+
+# ------------------------------------------------------------------
+# 9.  Summary + plots
+# ------------------------------------------------------------------
+def summary(model, accnt, log, name):
+    print(f"\n{name}: final acc={accuracy(model):.2f}%  "
+          f"ε={accnt.get_epsilon(DELTA):.2f}")
+    plot_curves(log, f" ({name}, {PUBLIC_METHOD})")
+
+# ------------------------------------------------------------------
+# 10.  Dispatcher
+# ------------------------------------------------------------------
+if __name__ == "__main__":
+    print(f"Experiment: {EXPERIMENT} • PUBLIC_METHOD={PUBLIC_METHOD} "
+          f"• DEBUG={'on' if DEBUG else 'off'}")
+    print(f"Private data : {N_PRIVATE} CIFAR‑10 images")
+    print(f"Public batch : {PUB_BATCH} synthetic samples\n")
+
+    SAMPLES_PER_CLASS = int(os.getenv("N_SHOW", "8"))   # one row length
+
+    # -----------------------------------------------------------
+    # helper to un-normalise tensors back to RGB [0,1]
+    # -----------------------------------------------------------
+    def denorm(batch, mean=mean, std=std):
+        m = torch.tensor(mean, device=batch.device).view(3, 1, 1)
+        s = torch.tensor(std , device=batch.device).view(3, 1, 1)
+        return (batch * s + m).clamp(0, 1)
+
+    # -----------------------------------------------------------
+    # collect synthetic samples from the diffusion buffer
+    # -----------------------------------------------------------
+    synth_by_class = {c: [] for c in range(10)}
+    with torch.no_grad():
+        while min(len(v) for v in synth_by_class.values()) < SAMPLES_PER_CLASS:
+            Xs, ys = next(train_pub)        # iterator already on DEVICE
+            for x, y in zip(Xs, ys):
+                if len(synth_by_class[int(y)]) < SAMPLES_PER_CLASS:
+                    synth_by_class[int(y)].append(x.cpu())
+
+    # -----------------------------------------------------------
+    # collect real CIFAR-10 test images
+    # -----------------------------------------------------------
+    real_by_class = {c: [] for c in range(10)}
+    for img, lab in test_set:
+        if len(real_by_class[lab]) < SAMPLES_PER_CLASS:
+            real_by_class[lab].append(img)
+        if min(len(v) for v in real_by_class.values()) == SAMPLES_PER_CLASS:
+            break
+
+    # -----------------------------------------------------------
+    # visualise
+    # -----------------------------------------------------------
+    def show_grid(by_class_dict, title):
+        rows = []
+        for c in range(10):
+            row = torch.stack(by_class_dict[c], 0)           # (N,3,32,32)
+            rows.append(denorm(row))
+        grid = make_grid(torch.cat(rows, 0),
+                         nrow=SAMPLES_PER_CLASS,
+                         padding=2).permute(1, 2, 0).numpy()
+        plt.figure(figsize=(SAMPLES_PER_CLASS, 10))
+        plt.imshow(grid)
+        plt.axis("off")
+        plt.title(title, fontsize=14)
+        plt.show()
+
+    show_grid(real_by_class,   "REAL CIFAR-10 (test set)")
+    show_grid(synth_by_class,  "SYNTHETIC (Consistency-Decoder)")
+
+
+    if   EXPERIMENT == "central_priv":   train_central(False)
+    elif EXPERIMENT == "central_pub":    train_central(True)
+    elif EXPERIMENT == "local_priv":     train_local(False)
+    elif EXPERIMENT == "local_pub":      train_local(True)
+    elif EXPERIMENT == "scaffold_priv":  train_scaffold(False)
+    elif EXPERIMENT == "scaffold_pub":   train_scaffold(True)
+    else: raise ValueError("Unknown EXPERIMENT")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 torch
 torchvision
 opacus==1.4.0
+psutil
+matplotlib
+diffusers
 
 # Machine-learning utilities
 scikit-learn==1.5.0

--- a/run_experiment.ipynb
+++ b/run_experiment.ipynb
@@ -1,144 +1,164 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "937127df",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "!git clone https://github.com/peacefulmind111111/privacy-pipeline.git\n",
-        "%cd privacy-pipeline\n",
-        "%cd privacy_pipeline"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "64248317",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "!pip install -r requirements.txt\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "c02cdbe0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from dataclasses import asdict\n",
-        "from privacy_pipeline.config import ExperimentConfig\n",
-        "from privacy_pipeline.training import train, train_with_outlier_clipping\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "b6a1463e",
-      "metadata": {},
-      "outputs": [
+    "cells": [
         {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "{'seed': 0, 'batch_size': 512, 'lr': 0.05, 'outer_momentum': 0.9, 'inner_momentum': 0.1, 'noise_mult': 1.0, 'delta': 1e-05, 'num_epochs': 20, 'c_start': 4.0, 'c_end': 2.0, 'default_clip': 1.0, 'outlier_clip': 0.5, 'high_err_threshold': 0.95, 'drop_after_frac': 0.6, 'self_aug_factor': 3, 'dataset_mean': (0.4914, 0.4822, 0.4465), 'dataset_std': (0.247, 0.2435, 0.2616), 'schedule_milestones': [12, 18], 'schedule_gamma': 0.1, 'max_momentum_size': 10000, 'device': device(type='cpu')}\n"
-          ]
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "937127df",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "!git clone https://github.com/peacefulmind111111/privacy-pipeline.git\n",
+                "%cd privacy-pipeline\n",
+                "%cd privacy_pipeline"
+            ]
         },
         {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "100%|██████████| 170M/170M [01:23<00:00, 2.03MB/s] \n",
-            "c:\\Users\\justi\\miniconda3\\Lib\\site-packages\\torch\\nn\\modules\\module.py:1842: FutureWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.\n",
-            "  self._maybe_warn_non_full_backward_hook(args, result, grad_fn)\n"
-          ]
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "64248317",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "!pip install -r requirements.txt\n"
+            ]
         },
         {
-          "ename": "KeyboardInterrupt",
-          "evalue": "",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-            "Cell \u001b[1;32mIn[3], line 17\u001b[0m\n\u001b[0;32m      1\u001b[0m baseline_cfg \u001b[38;5;241m=\u001b[39m ExperimentConfig(\n\u001b[0;32m      2\u001b[0m     num_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m20\u001b[39m,\n\u001b[0;32m      3\u001b[0m     batch_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m512\u001b[39m,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m     14\u001b[0m     max_momentum_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10000\u001b[39m,\n\u001b[0;32m     15\u001b[0m )\n\u001b[0;32m     16\u001b[0m \u001b[38;5;28mprint\u001b[39m(asdict(baseline_cfg))\n\u001b[1;32m---> 17\u001b[0m \u001b[43mtrain\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbaseline_cfg\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43moutputs/baseline_run\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
-            "File \u001b[1;32mc:\\Users\\justi\\OneDrive\\Documents\\GitHub\\privacy-pipeline\\privacy_pipeline\\training.py:71\u001b[0m, in \u001b[0;36mtrain\u001b[1;34m(cfg, output_dir, plot_every)\u001b[0m\n\u001b[0;32m     68\u001b[0m clip_val \u001b[38;5;241m=\u001b[39m cfg\u001b[38;5;241m.\u001b[39mc_start \u001b[38;5;241m+\u001b[39m (cfg\u001b[38;5;241m.\u001b[39mc_end \u001b[38;5;241m-\u001b[39m cfg\u001b[38;5;241m.\u001b[39mc_start) \u001b[38;5;241m*\u001b[39m frac\n\u001b[0;32m     70\u001b[0m X, y \u001b[38;5;241m=\u001b[39m X\u001b[38;5;241m.\u001b[39mto(device), y\u001b[38;5;241m.\u001b[39mto(device)\n\u001b[1;32m---> 71\u001b[0m batch_v, unique_count \u001b[38;5;241m=\u001b[39m \u001b[43mcompute_per_id_momentum\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m     72\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdp_net\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43midxs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmomentum_dict\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcfg\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minner_momentum\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\n\u001b[0;32m     73\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     74\u001b[0m preclip_vecs \u001b[38;5;241m=\u001b[39m [g \u001b[38;5;28;01mfor\u001b[39;00m (_, g) \u001b[38;5;129;01min\u001b[39;00m batch_v]\n\u001b[0;32m     75\u001b[0m pre_l1, pre_l2, pre_cos \u001b[38;5;241m=\u001b[39m measure_distribution(preclip_vecs)\n",
-            "File \u001b[1;32mc:\\Users\\justi\\OneDrive\\Documents\\GitHub\\privacy-pipeline\\privacy_pipeline\\momentum.py:57\u001b[0m, in \u001b[0;36mcompute_per_id_momentum\u001b[1;34m(dp_model, X, y, idxs, momentum_dict, inner_momentum, device, base_size)\u001b[0m\n\u001b[0;32m     55\u001b[0m             param_vecs[i] \u001b[38;5;241m=\u001b[39m gs_flat[i]\n\u001b[0;32m     56\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m---> 57\u001b[0m             param_vecs[i] \u001b[38;5;241m=\u001b[39m \u001b[43mtorch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcat\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mparam_vecs\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgs_flat\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m     58\u001b[0m     p\u001b[38;5;241m.\u001b[39mgrad_sample \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m     60\u001b[0m group_dict: Dict[\u001b[38;5;28mint\u001b[39m, List[torch\u001b[38;5;241m.\u001b[39mTensor]] \u001b[38;5;241m=\u001b[39m {}\n",
-            "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
-          ]
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "c02cdbe0",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from dataclasses import asdict\n",
+                "from privacy_pipeline.config import ExperimentConfig\n",
+                "from privacy_pipeline.training import train, train_with_outlier_clipping\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "b6a1463e",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "{'seed': 0, 'batch_size': 512, 'lr': 0.05, 'outer_momentum': 0.9, 'inner_momentum': 0.1, 'noise_mult': 1.0, 'delta': 1e-05, 'num_epochs': 20, 'c_start': 4.0, 'c_end': 2.0, 'default_clip': 1.0, 'outlier_clip': 0.5, 'high_err_threshold': 0.95, 'drop_after_frac': 0.6, 'self_aug_factor': 3, 'dataset_mean': (0.4914, 0.4822, 0.4465), 'dataset_std': (0.247, 0.2435, 0.2616), 'schedule_milestones': [12, 18], 'schedule_gamma': 0.1, 'max_momentum_size': 10000, 'device': device(type='cpu')}\n"
+                    ]
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 170M/170M [01:23<00:00, 2.03MB/s] \n",
+                        "c:\\Users\\justi\\miniconda3\\Lib\\site-packages\\torch\\nn\\modules\\module.py:1842: FutureWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.\n",
+                        "  self._maybe_warn_non_full_backward_hook(args, result, grad_fn)\n"
+                    ]
+                },
+                {
+                    "ename": "KeyboardInterrupt",
+                    "evalue": "",
+                    "output_type": "error",
+                    "traceback": [
+                        "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+                        "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+                        "Cell \u001b[1;32mIn[3], line 17\u001b[0m\n\u001b[0;32m      1\u001b[0m baseline_cfg \u001b[38;5;241m=\u001b[39m ExperimentConfig(\n\u001b[0;32m      2\u001b[0m     num_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m20\u001b[39m,\n\u001b[0;32m      3\u001b[0m     batch_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m512\u001b[39m,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m     14\u001b[0m     max_momentum_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10000\u001b[39m,\n\u001b[0;32m     15\u001b[0m )\n\u001b[0;32m     16\u001b[0m \u001b[38;5;28mprint\u001b[39m(asdict(baseline_cfg))\n\u001b[1;32m---> 17\u001b[0m \u001b[43mtrain\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbaseline_cfg\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43moutputs/baseline_run\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+                        "File \u001b[1;32mc:\\Users\\justi\\OneDrive\\Documents\\GitHub\\privacy-pipeline\\privacy_pipeline\\training.py:71\u001b[0m, in \u001b[0;36mtrain\u001b[1;34m(cfg, output_dir, plot_every)\u001b[0m\n\u001b[0;32m     68\u001b[0m clip_val \u001b[38;5;241m=\u001b[39m cfg\u001b[38;5;241m.\u001b[39mc_start \u001b[38;5;241m+\u001b[39m (cfg\u001b[38;5;241m.\u001b[39mc_end \u001b[38;5;241m-\u001b[39m cfg\u001b[38;5;241m.\u001b[39mc_start) \u001b[38;5;241m*\u001b[39m frac\n\u001b[0;32m     70\u001b[0m X, y \u001b[38;5;241m=\u001b[39m X\u001b[38;5;241m.\u001b[39mto(device), y\u001b[38;5;241m.\u001b[39mto(device)\n\u001b[1;32m---> 71\u001b[0m batch_v, unique_count \u001b[38;5;241m=\u001b[39m \u001b[43mcompute_per_id_momentum\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m     72\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdp_net\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43midxs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmomentum_dict\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcfg\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minner_momentum\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\n\u001b[0;32m     73\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     74\u001b[0m preclip_vecs \u001b[38;5;241m=\u001b[39m [g \u001b[38;5;28;01mfor\u001b[39;00m (_, g) \u001b[38;5;129;01min\u001b[39;00m batch_v]\n\u001b[0;32m     75\u001b[0m pre_l1, pre_l2, pre_cos \u001b[38;5;241m=\u001b[39m measure_distribution(preclip_vecs)\n",
+                        "File \u001b[1;32mc:\\Users\\justi\\OneDrive\\Documents\\GitHub\\privacy-pipeline\\privacy_pipeline\\momentum.py:57\u001b[0m, in \u001b[0;36mcompute_per_id_momentum\u001b[1;34m(dp_model, X, y, idxs, momentum_dict, inner_momentum, device, base_size)\u001b[0m\n\u001b[0;32m     55\u001b[0m             param_vecs[i] \u001b[38;5;241m=\u001b[39m gs_flat[i]\n\u001b[0;32m     56\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m---> 57\u001b[0m             param_vecs[i] \u001b[38;5;241m=\u001b[39m \u001b[43mtorch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcat\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mparam_vecs\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgs_flat\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m     58\u001b[0m     p\u001b[38;5;241m.\u001b[39mgrad_sample \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m     60\u001b[0m group_dict: Dict[\u001b[38;5;28mint\u001b[39m, List[torch\u001b[38;5;241m.\u001b[39mTensor]] \u001b[38;5;241m=\u001b[39m {}\n",
+                        "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
+                    ]
+                }
+            ],
+            "source": [
+                "baseline_cfg = ExperimentConfig(\n",
+                "    num_epochs=20,\n",
+                "    batch_size=512,\n",
+                "    lr=0.05,\n",
+                "    outer_momentum=0.9,\n",
+                "    inner_momentum=0.10,\n",
+                "    noise_mult=1.0,\n",
+                "    delta=1e-5,\n",
+                "    c_start=4.0,\n",
+                "    c_end=2.0,\n",
+                "    self_aug_factor=3,\n",
+                "    schedule_milestones=[12, 18],\n",
+                "    schedule_gamma=0.1,\n",
+                "    max_momentum_size=10000,\n",
+                ")\n",
+                "print(asdict(baseline_cfg))\n",
+                "train(baseline_cfg, 'outputs/baseline_run')\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1d44eba1",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "outlier_cfg = ExperimentConfig(\n",
+                "    seed=0,\n",
+                "    batch_size=1000,\n",
+                "    lr=0.1,\n",
+                "    outer_momentum=0.9,\n",
+                "    inner_momentum=0.08,\n",
+                "    noise_mult=1.5,\n",
+                "    delta=1e-5,\n",
+                "    num_epochs=50,\n",
+                "    self_aug_factor=3,\n",
+                "    default_clip=1.0,\n",
+                "    outlier_clip=0.5,\n",
+                "    high_err_threshold=0.95,\n",
+                "    drop_after_frac=0.6,\n",
+                "    schedule_milestones=[30, 45],\n",
+                "    schedule_gamma=0.1,\n",
+                "    max_momentum_size=10000,\n",
+                ")\n",
+                "print(asdict(outlier_cfg))\n",
+                "train_with_outlier_clipping(outlier_cfg, 'outputs/outlier_run')\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Virtual sample projection experiment\n",
+                "!python dp_virtual_projection_population_only.py\n"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "source": [
+                "# Local DP-SGD experiment (private + public)\n",
+                "!EXPERIMENT=local_pub PUBLIC_METHOD=mixsub python local_dpsgd_experiment.py\n"
+            ],
+            "execution_count": null,
+            "outputs": []
         }
-      ],
-      "source": [
-        "baseline_cfg = ExperimentConfig(\n",
-        "    num_epochs=20,\n",
-        "    batch_size=512,\n",
-        "    lr=0.05,\n",
-        "    outer_momentum=0.9,\n",
-        "    inner_momentum=0.10,\n",
-        "    noise_mult=1.0,\n",
-        "    delta=1e-5,\n",
-        "    c_start=4.0,\n",
-        "    c_end=2.0,\n",
-        "    self_aug_factor=3,\n",
-        "    schedule_milestones=[12, 18],\n",
-        "    schedule_gamma=0.1,\n",
-        "    max_momentum_size=10000,\n",
-        ")\n",
-        "print(asdict(baseline_cfg))\n",
-        "train(baseline_cfg, 'outputs/baseline_run')\n"
-      ]
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "base",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.12.11"
+        }
     },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1d44eba1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "outlier_cfg = ExperimentConfig(\n",
-        "    seed=0,\n",
-        "    batch_size=1000,\n",
-        "    lr=0.1,\n",
-        "    outer_momentum=0.9,\n",
-        "    inner_momentum=0.08,\n",
-        "    noise_mult=1.5,\n",
-        "    delta=1e-5,\n",
-        "    num_epochs=50,\n",
-        "    self_aug_factor=3,\n",
-        "    default_clip=1.0,\n",
-        "    outlier_clip=0.5,\n",
-        "    high_err_threshold=0.95,\n",
-        "    drop_after_frac=0.6,\n",
-        "    schedule_milestones=[30, 45],\n",
-        "    schedule_gamma=0.1,\n",
-        "    max_momentum_size=10000,\n",
-        ")\n",
-        "print(asdict(outlier_cfg))\n",
-        "train_with_outlier_clipping(outlier_cfg, 'outputs/outlier_run')\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "base",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.11"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 5
+    "nbformat": 4,
+    "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- include training diagnostics for projection experiments tracking L2 distance and cosine similarity
- add standalone virtual sample projection and local DP-SGD scripts with public/private mixing
- expand notebook and dependencies for new experiments

## Testing
- `python -m py_compile dp_virtual_projection_population_only.py local_dpsgd_experiment.py privacy_pipeline/*.py`

------
https://chatgpt.com/codex/tasks/task_e_689190cbaf4483268cf6a3bdf6134fd4