### PR TITLE
Harmonize experiment outputs and parameters

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DP experiments")
+    parser.add_argument(
+        "--method",
+        choices=["dp_virtual_projection", "local_dpsgd"],
+        required=True,
+        help="Which experiment to run",
+    )
+    parser.add_argument(
+        "--params",
+        type=str,
+        default="{}",
+        help="JSON string of hyperparameters to override",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=os.path.join("outputs", "metrics.json"),
+        help="Where to save metrics JSON",
+    )
+    args = parser.parse_args()
+    params = json.loads(args.params)
+
+    if args.method == "dp_virtual_projection":
+        from dp_virtual_projection_population_only import main_run
+
+        results = main_run(params=params)
+    else:
+        from local_dpsgd_experiment import run_experiment as run_local
+
+        results = run_local(params=params)
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Allow overriding hyperparameters in `dp_virtual_projection_population_only` and emit a standardized metrics JSON report
- Add parameter override and JSON logging support for `local_dpsgd_experiment`
- Introduce `run_experiment.py` dispatcher to switch between experiments with a common interface

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891bf9a90e08326a6d6690b7d4fbd45