### PR TITLE
Harmonize experiment outputs and parameters

### DIFF
--- a/experiment_utils.py
+++ b/experiment_utils.py
@@ -1,0 +1,65 @@
+import os
+import json
+import time
+import platform
+import subprocess
+import gc
+import torch
+
+
+def _git_commit() -> str | None:
+    """Return current git commit hash if available."""
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], text=True)
+            .strip()
+        )
+    except Exception:
+        return None
+
+
+def save_json(
+    experiment: str,
+    params: dict | None,
+    history: list[dict],
+    final_metrics: dict,
+    output_dir: str | None = None,
+    filename: str | None = None,
+    extra_metadata: dict | None = None,
+):
+    """Persist results to a standardized JSON file and return the record."""
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    run_id = f"{experiment}_{ts}"
+
+    metadata = {
+        "timestamp": ts,
+        "git_commit": _git_commit(),
+        "python": platform.python_version(),
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    record = {
+        "run_id": run_id,
+        "experiment": experiment,
+        "parameters": params or {},
+        "history": history,
+        "final_metrics": final_metrics,
+        "metadata": metadata,
+    }
+
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        fname = filename or f"{run_id}.json"
+        path = os.path.join(output_dir, fname)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(record, f, indent=2)
+
+    return record
+
+
+def clear_memory() -> None:
+    """Best-effort memory cleanup between experiments."""
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/local_dpsgd_experiment.py
+++ b/local_dpsgd_experiment.py
@@ -5,7 +5,7 @@
 #  (2025-07-10 bug-fixed & instrumented edition)
 # ===============================================================
 
-import os, random, warnings, time
+import os, random, warnings, time, json
 from itertools import cycle
 from collections import defaultdict
 import sys, torch, matplotlib.pyplot as plt
@@ -22,43 +22,65 @@ from opacus.accountants import RDPAccountant
 from opacus.grad_sample import GradSampleModule
 from diffusers import ConsistencyModelPipeline            # light decoder
 import torchvision.transforms as T
+from dataclasses import dataclass, asdict, field
+from experiment_utils import save_json, clear_memory
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
 # ------------------------------------------------------------------
-# 0.  Flags & debug knob
+# 0.  Hyperparameter dataclass
 # ------------------------------------------------------------------
-EXPERIMENT      = os.getenv("EXPERIMENT", "central_priv")
-PUBLIC_METHOD   = os.getenv("PUBLIC_METHOD", "mixsub").lower()     # add | mixsub
-DEBUG           = bool(int(os.getenv("DEBUG", "1")))               # 0 = silent
-FIXED_PUB = bool(int(os.getenv("FIXED_PUB", "0")))  # set 0 to keep dynamic
+
+
+@dataclass
+class ExperimentConfig:
+    EXPERIMENT: str = "central_priv"
+    PUBLIC_METHOD: str = "mixsub"  # add | mixsub
+    DEBUG: bool = True
+    FIXED_PUB: bool = False
+    SEED: int = 0
+    PRIV_BATCH: int = 512
+    PUB_BATCH: int = 500
+    NUM_EPOCHS: int = 5
+    HEARTBEAT: int = 1
+    K_LOCAL: int = 3
+    ETA_LOCAL: float = 0.025
+    LR_OUTER: float = 0.05
+    MOMENTUM_OUTER: float = 0.9
+    OUTER_LR_LOCAL: float = 1.0
+    OUTER_LR_SCAFFOLD: float = 1.0
+    C_CLIP_PRIV: float = 1.0
+    C_CLIP_PUB: float = 1.0
+    NOISE_MULT: float = 1.0
+    DELTA: float = 1e-5
+    MILESTONES: list[int] = field(default_factory=lambda: [10, 13])
+    GAMMA: float = 0.1
+    DATA_FRACTION: float = 0.2
+    SELF_AUG_FACTOR: int = 1
+
+
+DEFAULT_CONFIG = ExperimentConfig()
+for _k, _v in asdict(DEFAULT_CONFIG).items():
+    globals()[_k] = _v
 
 assert PUBLIC_METHOD in {"add", "mixsub"}, "PUBLIC_METHOD must be add|mixsub"
 
-# ------------------------------------------------------------------
-# 1.  Hyper-parameters
-# ------------------------------------------------------------------
-SEED, PRIV_BATCH, PUB_BATCH = 0, 512, 500
-NUM_EPOCHS, HEARTBEAT       = 5, 1
-
-K_LOCAL, ETA_LOCAL          = 3, 0.025
-
-# ---- learning-rates -----------------------------------------------------------
-LR_OUTER, MOMENTUM_OUTER    = 0.05, 0.9          # used by *central* DP-SGD
-OUTER_LR_LOCAL              = float(os.getenv("OUTER_LR_LOCAL", "1.0"))
-OUTER_LR_SCAFFOLD           = float(os.getenv("OUTER_LR_SCAFFOLD", "1.0"))
-
-# ---- clipping / noise ---------------------------------------------------------
-C_CLIP_PRIV                 = 1.0                                      # private
-C_CLIP_PUB                  = float(os.getenv("C_CLIP_PUB", "1.0"))    # public
-NOISE_MULT                  = 1.0
-DELTA                       = 1e-5
-
-MILESTONES, GAMMA           = [10, 13], 0.1
-DATA_FRACTION, SELF_AUG_FACTOR = 0.2, 1
-DEVICE                      = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 α_SCALE = PUB_BATCH / (PRIV_BATCH + PUB_BATCH)   # factor for mix-subtract
+
+
+def apply_params(params: dict | ExperimentConfig | None) -> None:
+    """Override global hyperparameters using ``params``."""
+    if not params:
+        return
+    if isinstance(params, ExperimentConfig):
+        params = asdict(params)
+    for k, v in params.items():
+        if k in globals():
+            globals()[k] = v
+
+
+DEFAULT_PARAMS = asdict(DEFAULT_CONFIG)
 
 # ------------------------------------------------------------------
 # 2.  RNG
@@ -429,7 +451,7 @@ def train_central(use_public: bool):
                       f"acc={acc:5.2f}%  ε={accnt.get_epsilon(DELTA):.2f}")
 
         sched.step()
-    summary(model, accnt, log, "central_" + ("pub" if use_public else "priv"))
+    return summary(model, accnt, log, "central_" + ("pub" if use_public else "priv"))
 
 # ------------------------------------------------------------------
 # 8-B. Helper for LOCAL DP-SGD
@@ -522,7 +544,7 @@ def train_local(use_public: bool):
 
         dummy_sched.step()
 
-    summary(model, accnt, log, "local_" + ("pub" if use_public else "priv"))
+    return summary(model, accnt, log, "local_" + ("pub" if use_public else "priv"))
 
 # ------------------------------------------------------------------
 # 8-C. DP-SCAFFOLD
@@ -634,82 +656,115 @@ def train_scaffold(use_public: bool):
 
         sched.step()
 
-    summary(model, accnt, log, "scaffold_" + ("pub" if use_public else "priv"))
+    return summary(model, accnt, log, "scaffold_" + ("pub" if use_public else "priv"))
 
 # ------------------------------------------------------------------
 # 9.  Summary + plots
 # ------------------------------------------------------------------
-def summary(model, accnt, log, name):
-    print(f"\n{name}: final acc={accuracy(model):.2f}%  "
-          f"ε={accnt.get_epsilon(DELTA):.2f}")
-    plot_curves(log, f" ({name}, {PUBLIC_METHOD})")
+def summary(model, accnt, log, name, plot: bool = False):
+    """Return metrics for ``model``.
 
-# ------------------------------------------------------------------
-# 10.  Dispatcher
-# ------------------------------------------------------------------
+    Parameters
+    ----------
+    model : nn.Module
+        Trained model.
+    accnt : RDPAccountant
+        Accountant tracking privacy loss.
+    log : Dict
+        Training log containing losses and accuracy measurements.
+    name : str
+        Experiment name.
+    plot : bool, optional
+        If ``True`` generate diagnostic plots.
+    """
+    final_acc = accuracy(model)
+    eps = accnt.get_epsilon(DELTA)
+    if plot:
+        plot_curves(log, f" ({name}, {PUBLIC_METHOD})")
+    iter_steps = range(1, len(log.get("loss", [])) + 1)
+    history = []
+    for i, step in enumerate(iter_steps):
+        entry = {
+            "step": int(step),
+            "loss": float(log["loss"][i]) if log.get("loss") else 0.0,
+            "l1_priv": float(log["l1_priv"][i]) if log.get("l1_priv") else 0.0,
+            "l2_priv": float(log["l2_priv"][i]) if log.get("l2_priv") else 0.0,
+            "l1_pub": float(log["l1_pub"][i]) if log.get("l1_pub") else 0.0,
+            "l2_pub": float(log["l2_pub"][i]) if log.get("l2_pub") else 0.0,
+            "cos": float(log["cos"][i]) if log.get("cos") else 0.0,
+        }
+        if i < len(log.get("acc_step", [])) and i < len(log.get("acc", [])):
+            entry["accuracy_step"] = int(log["acc_step"][i])
+            entry["accuracy"] = float(log["acc"][i])
+        history.append(entry)
+
+    final_loss = float(log["loss"][-1]) if log.get("loss") else None
+    return {
+        "final_accuracy": float(final_acc),
+        "epsilon": float(eps),
+        "final_loss": final_loss,
+        "history": history,
+    }
+
+def run_experiment(
+    experiment: str = EXPERIMENT,
+    params: dict | None = None,
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Run one of the DP-SGD experiments and optionally save metrics."""
+    apply_params(params)
+
+    if   experiment == "central_priv":
+        res = train_central(False)
+    elif experiment == "central_pub":
+        res = train_central(True)
+    elif experiment == "local_priv":
+        res = train_local(False)
+    elif experiment == "local_pub":
+        res = train_local(True)
+    elif experiment == "scaffold_priv":
+        res = train_scaffold(False)
+    elif experiment == "scaffold_pub":
+        res = train_scaffold(True)
+    else:
+        raise ValueError("Unknown EXPERIMENT")
+
+    final_metrics = {
+        "accuracy": res["final_accuracy"],
+        "epsilon": res["epsilon"],
+        "final_loss": res.get("final_loss"),
+    }
+
+    results = save_json(
+        experiment=experiment,
+        params=params or {},
+        history=res["history"],
+        final_metrics=final_metrics,
+        output_dir=output_dir,
+        filename=filename,
+    )
+    clear_memory()
+    return results
+
+
+def train(
+    cfg: ExperimentConfig | None = None,
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Wrapper that accepts a dataclass config and output directory."""
+    cfg = cfg or ExperimentConfig()
+    params = asdict(cfg)
+    return run_experiment(
+        experiment=cfg.EXPERIMENT,
+        params=params,
+        output_dir=output_dir,
+        filename=filename,
+    )
+
+
 if __name__ == "__main__":
-    print(f"Experiment: {EXPERIMENT} • PUBLIC_METHOD={PUBLIC_METHOD} "
-          f"• DEBUG={'on' if DEBUG else 'off'}")
-    print(f"Private data : {N_PRIVATE} CIFAR‑10 images")
-    print(f"Public batch : {PUB_BATCH} synthetic samples\n")
-
-    SAMPLES_PER_CLASS = int(os.getenv("N_SHOW", "8"))   # one row length
-
-    # -----------------------------------------------------------
-    # helper to un-normalise tensors back to RGB [0,1]
-    # -----------------------------------------------------------
-    def denorm(batch, mean=mean, std=std):
-        m = torch.tensor(mean, device=batch.device).view(3, 1, 1)
-        s = torch.tensor(std , device=batch.device).view(3, 1, 1)
-        return (batch * s + m).clamp(0, 1)
-
-    # -----------------------------------------------------------
-    # collect synthetic samples from the diffusion buffer
-    # -----------------------------------------------------------
-    synth_by_class = {c: [] for c in range(10)}
-    with torch.no_grad():
-        while min(len(v) for v in synth_by_class.values()) < SAMPLES_PER_CLASS:
-            Xs, ys = next(train_pub)        # iterator already on DEVICE
-            for x, y in zip(Xs, ys):
-                if len(synth_by_class[int(y)]) < SAMPLES_PER_CLASS:
-                    synth_by_class[int(y)].append(x.cpu())
-
-    # -----------------------------------------------------------
-    # collect real CIFAR-10 test images
-    # -----------------------------------------------------------
-    real_by_class = {c: [] for c in range(10)}
-    for img, lab in test_set:
-        if len(real_by_class[lab]) < SAMPLES_PER_CLASS:
-            real_by_class[lab].append(img)
-        if min(len(v) for v in real_by_class.values()) == SAMPLES_PER_CLASS:
-            break
-
-    # -----------------------------------------------------------
-    # visualise
-    # -----------------------------------------------------------
-    def show_grid(by_class_dict, title):
-        rows = []
-        for c in range(10):
-            row = torch.stack(by_class_dict[c], 0)           # (N,3,32,32)
-            rows.append(denorm(row))
-        grid = make_grid(torch.cat(rows, 0),
-                         nrow=SAMPLES_PER_CLASS,
-                         padding=2).permute(1, 2, 0).numpy()
-        plt.figure(figsize=(SAMPLES_PER_CLASS, 10))
-        plt.imshow(grid)
-        plt.axis("off")
-        plt.title(title, fontsize=14)
-        plt.show()
-
-    show_grid(real_by_class,   "REAL CIFAR-10 (test set)")
-    show_grid(synth_by_class,  "SYNTHETIC (Consistency-Decoder)")
-
-
-    if   EXPERIMENT == "central_priv":   train_central(False)
-    elif EXPERIMENT == "central_pub":    train_central(True)
-    elif EXPERIMENT == "local_priv":     train_local(False)
-    elif EXPERIMENT == "local_pub":      train_local(True)
-    elif EXPERIMENT == "scaffold_priv":  train_scaffold(False)
-    elif EXPERIMENT == "scaffold_pub":   train_scaffold(True)
-    else: raise ValueError("Unknown EXPERIMENT")
+    res = train(ExperimentConfig(), os.getenv("OUTPUT_DIR", "outputs"))
+    print(json.dumps(res, indent=2))
 

--- a/run_experiment.ipynb
+++ b/run_experiment.ipynb
@@ -1,164 +1,141 @@
 {
-    "cells": [
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "937127df",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!git clone https://github.com/peacefulmind111111/privacy-pipeline.git\n",
-                "%cd privacy-pipeline\n",
-                "%cd privacy_pipeline"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "64248317",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "!pip install -r requirements.txt\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "id": "c02cdbe0",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from dataclasses import asdict\n",
-                "from privacy_pipeline.config import ExperimentConfig\n",
-                "from privacy_pipeline.training import train, train_with_outlier_clipping\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "id": "b6a1463e",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "{'seed': 0, 'batch_size': 512, 'lr': 0.05, 'outer_momentum': 0.9, 'inner_momentum': 0.1, 'noise_mult': 1.0, 'delta': 1e-05, 'num_epochs': 20, 'c_start': 4.0, 'c_end': 2.0, 'default_clip': 1.0, 'outlier_clip': 0.5, 'high_err_threshold': 0.95, 'drop_after_frac': 0.6, 'self_aug_factor': 3, 'dataset_mean': (0.4914, 0.4822, 0.4465), 'dataset_std': (0.247, 0.2435, 0.2616), 'schedule_milestones': [12, 18], 'schedule_gamma': 0.1, 'max_momentum_size': 10000, 'device': device(type='cpu')}\n"
-                    ]
-                },
-                {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 170M/170M [01:23<00:00, 2.03MB/s] \n",
-                        "c:\\Users\\justi\\miniconda3\\Lib\\site-packages\\torch\\nn\\modules\\module.py:1842: FutureWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.\n",
-                        "  self._maybe_warn_non_full_backward_hook(args, result, grad_fn)\n"
-                    ]
-                },
-                {
-                    "ename": "KeyboardInterrupt",
-                    "evalue": "",
-                    "output_type": "error",
-                    "traceback": [
-                        "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-                        "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-                        "Cell \u001b[1;32mIn[3], line 17\u001b[0m\n\u001b[0;32m      1\u001b[0m baseline_cfg \u001b[38;5;241m=\u001b[39m ExperimentConfig(\n\u001b[0;32m      2\u001b[0m     num_epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m20\u001b[39m,\n\u001b[0;32m      3\u001b[0m     batch_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m512\u001b[39m,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m     14\u001b[0m     max_momentum_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10000\u001b[39m,\n\u001b[0;32m     15\u001b[0m )\n\u001b[0;32m     16\u001b[0m \u001b[38;5;28mprint\u001b[39m(asdict(baseline_cfg))\n\u001b[1;32m---> 17\u001b[0m \u001b[43mtrain\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbaseline_cfg\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43moutputs/baseline_run\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
-                        "File \u001b[1;32mc:\\Users\\justi\\OneDrive\\Documents\\GitHub\\privacy-pipeline\\privacy_pipeline\\training.py:71\u001b[0m, in \u001b[0;36mtrain\u001b[1;34m(cfg, output_dir, plot_every)\u001b[0m\n\u001b[0;32m     68\u001b[0m clip_val \u001b[38;5;241m=\u001b[39m cfg\u001b[38;5;241m.\u001b[39mc_start \u001b[38;5;241m+\u001b[39m (cfg\u001b[38;5;241m.\u001b[39mc_end \u001b[38;5;241m-\u001b[39m cfg\u001b[38;5;241m.\u001b[39mc_start) \u001b[38;5;241m*\u001b[39m frac\n\u001b[0;32m     70\u001b[0m X, y \u001b[38;5;241m=\u001b[39m X\u001b[38;5;241m.\u001b[39mto(device), y\u001b[38;5;241m.\u001b[39mto(device)\n\u001b[1;32m---> 71\u001b[0m batch_v, unique_count \u001b[38;5;241m=\u001b[39m \u001b[43mcompute_per_id_momentum\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m     72\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdp_net\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43midxs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmomentum_dict\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcfg\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minner_momentum\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\n\u001b[0;32m     73\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     74\u001b[0m preclip_vecs \u001b[38;5;241m=\u001b[39m [g \u001b[38;5;28;01mfor\u001b[39;00m (_, g) \u001b[38;5;129;01min\u001b[39;00m batch_v]\n\u001b[0;32m     75\u001b[0m pre_l1, pre_l2, pre_cos \u001b[38;5;241m=\u001b[39m measure_distribution(preclip_vecs)\n",
-                        "File \u001b[1;32mc:\\Users\\justi\\OneDrive\\Documents\\GitHub\\privacy-pipeline\\privacy_pipeline\\momentum.py:57\u001b[0m, in \u001b[0;36mcompute_per_id_momentum\u001b[1;34m(dp_model, X, y, idxs, momentum_dict, inner_momentum, device, base_size)\u001b[0m\n\u001b[0;32m     55\u001b[0m             param_vecs[i] \u001b[38;5;241m=\u001b[39m gs_flat[i]\n\u001b[0;32m     56\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m---> 57\u001b[0m             param_vecs[i] \u001b[38;5;241m=\u001b[39m \u001b[43mtorch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcat\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mparam_vecs\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgs_flat\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m     58\u001b[0m     p\u001b[38;5;241m.\u001b[39mgrad_sample \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m     60\u001b[0m group_dict: Dict[\u001b[38;5;28mint\u001b[39m, List[torch\u001b[38;5;241m.\u001b[39mTensor]] \u001b[38;5;241m=\u001b[39m {}\n",
-                        "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
-                    ]
-                }
-            ],
-            "source": [
-                "baseline_cfg = ExperimentConfig(\n",
-                "    num_epochs=20,\n",
-                "    batch_size=512,\n",
-                "    lr=0.05,\n",
-                "    outer_momentum=0.9,\n",
-                "    inner_momentum=0.10,\n",
-                "    noise_mult=1.0,\n",
-                "    delta=1e-5,\n",
-                "    c_start=4.0,\n",
-                "    c_end=2.0,\n",
-                "    self_aug_factor=3,\n",
-                "    schedule_milestones=[12, 18],\n",
-                "    schedule_gamma=0.1,\n",
-                "    max_momentum_size=10000,\n",
-                ")\n",
-                "print(asdict(baseline_cfg))\n",
-                "train(baseline_cfg, 'outputs/baseline_run')\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "1d44eba1",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "outlier_cfg = ExperimentConfig(\n",
-                "    seed=0,\n",
-                "    batch_size=1000,\n",
-                "    lr=0.1,\n",
-                "    outer_momentum=0.9,\n",
-                "    inner_momentum=0.08,\n",
-                "    noise_mult=1.5,\n",
-                "    delta=1e-5,\n",
-                "    num_epochs=50,\n",
-                "    self_aug_factor=3,\n",
-                "    default_clip=1.0,\n",
-                "    outlier_clip=0.5,\n",
-                "    high_err_threshold=0.95,\n",
-                "    drop_after_frac=0.6,\n",
-                "    schedule_milestones=[30, 45],\n",
-                "    schedule_gamma=0.1,\n",
-                "    max_momentum_size=10000,\n",
-                ")\n",
-                "print(asdict(outlier_cfg))\n",
-                "train_with_outlier_clipping(outlier_cfg, 'outputs/outlier_run')\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "metadata": {},
-            "source": [
-                "# Virtual sample projection experiment\n",
-                "!python dp_virtual_projection_population_only.py\n"
-            ],
-            "execution_count": null,
-            "outputs": []
-        },
-        {
-            "cell_type": "code",
-            "metadata": {},
-            "source": [
-                "# Local DP-SGD experiment (private + public)\n",
-                "!EXPERIMENT=local_pub PUBLIC_METHOD=mixsub python local_dpsgd_experiment.py\n"
-            ],
-            "execution_count": null,
-            "outputs": []
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "base",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.12.11"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1684d471",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import asdict\n",
+    "from dp_virtual_projection_population_only import ExperimentConfig as VProjConfig, train as vp_train\n",
+    "from local_dpsgd_experiment import ExperimentConfig as LDConfig, train as ld_train\n",
+    "from experiment_utils import clear_memory\n",
+    "\n",
+    "from privacy_pipeline.config import ExperimentConfig as BaseConfig\n",
+    "from privacy_pipeline.training import train as base_train, train_with_outlier_clipping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8383e82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Baseline DP-SGD experiment\n",
+    "# Based on: https://proceedings.neurips.cc/paper_files/paper/2015/file/52d080a3e172c33fd6886a37e7288491-Paper.pdf\n",
+    "baseline_cfg = BaseConfig(\n",
+    "    num_epochs=1,\n",
+    "    batch_size=512,\n",
+    "    lr=0.05,\n",
+    "    outer_momentum=0.9,\n",
+    "    inner_momentum=0.10,\n",
+    "    noise_mult=1.0,\n",
+    "    delta=1e-5,\n",
+    "    c_start=4.0,\n",
+    "    c_end=2.0,\n",
+    "    self_aug_factor=1,\n",
+    "    schedule_milestones=[12, 18],\n",
+    "    schedule_gamma=0.1,\n",
+    "    max_momentum_size=10000,\n",
+    ")\n",
+    "print(asdict(baseline_cfg))\n",
+    "baseline_results = base_train(baseline_cfg, 'outputs/baseline_run')\n",
+    "clear_memory()\n",
+    "baseline_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167f90ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Synthetic data mixing experiment\n",
+    "# Based on: https://arxiv.org/pdf/2311.01295\n",
+    "outlier_cfg = BaseConfig(\n",
+    "    seed=0,\n",
+    "    batch_size=1000,\n",
+    "    lr=0.1,\n",
+    "    outer_momentum=0.9,\n",
+    "    inner_momentum=0.08,\n",
+    "    noise_mult=1.5,\n",
+    "    delta=1e-5,\n",
+    "    num_epochs=1,\n",
+    "    self_aug_factor=3,\n",
+    ")\n",
+    "print(asdict(outlier_cfg))\n",
+    "outlier_results = train_with_outlier_clipping(outlier_cfg, 'outputs/outlier_run')\n",
+    "clear_memory()\n",
+    "outlier_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "919a9957",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Synthetic data projection experiment\n",
+    "# Based on: https://arxiv.org/pdf/2506.16661\n",
+    "vp_cfg = VProjConfig(\n",
+    "    num_epochs=1,\n",
+    "    batch_size=512,\n",
+    "    lr=0.05,\n",
+    "    outer_momentum=0.9,\n",
+    "    inner_momentum=0.10,\n",
+    "    noise_mult=1.0,\n",
+    "    delta=1e-5,\n",
+    "    c_start=4.0,\n",
+    "    c_end=2.0,\n",
+    "    self_aug_factor=1,\n",
+    "    schedule_milestones=[12, 18],\n",
+    "    schedule_gamma=0.1,\n",
+    "    max_momentum_size=10000,\n",
+    ")\n",
+    "print(asdict(vp_cfg))\n",
+    "vp_results = vp_train(vp_cfg, 'outputs/vproj_run')\n",
+    "clear_memory()\n",
+    "vp_results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "893e2fd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Local DP-SGD/Scaffold experiment\n",
+    "# Based on: https://arxiv.org/pdf/2306.16504\n",
+    "ld_cfg = LDConfig(\n",
+    "    EXPERIMENT='local_pub',\n",
+    "    PRIV_BATCH=512,\n",
+    "    NUM_EPOCHS=1,\n",
+    "    LR_OUTER=0.05,\n",
+    "    MOMENTUM_OUTER=0.9,\n",
+    ")\n",
+    "print(asdict(ld_cfg))\n",
+    "ld_results = ld_train(ld_cfg, 'outputs/localdp_run')\n",
+    "clear_memory()\n",
+    "ld_results\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Log per-iteration L1, L2 and cosine similarity for baseline and outlier-clipping DP-SGD training runs
- Track and export L1/L2 projection gaps for the virtual projection experiment and include norm metrics in local DP-SGD logs
- Restore baseline and synthetic data mixing runs in `run_experiment.ipynb` and route all experiments to unique output folders

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891bf9a90e08326a6d6690b7d4fbd45