### PR TITLE
Standardize JSON metrics with norm stats and unique filenames

### DIFF
--- a/privacy_pipeline/logger.py
+++ b/privacy_pipeline/logger.py
@@ -27,6 +27,16 @@ class ExperimentLogger:
                     "clip_value": float,
                     "grad_norm": float,
                     "lr": float,
+                    "pre_clip": {
+                        "l1_norm": float,
+                        "l2_norm": float,
+                        "cosine_similarity": float,
+                    },
+                    "post_clip": {
+                        "l1_norm": float,
+                        "l2_norm": float,
+                        "cosine_similarity": float,
+                    },
                 },
                 ...
             ],
@@ -45,14 +55,15 @@ class ExperimentLogger:
 
     def save(self, final_metrics: Dict[str, Any]) -> None:
         os.makedirs(self.output_dir, exist_ok=True)
+        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
         report = {
             "experiment_name": getattr(self.cfg, "experiment_name", "dp_experiment"),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": ts,
             "hyperparameters": _ensure_serializable(asdict(self.cfg)),
             "iterations": self.iterations,
             "final_metrics": final_metrics,
         }
-        path = os.path.join(self.output_dir, "metrics.json")
+        path = os.path.join(self.output_dir, f"metrics_{ts}.json")
         with open(path, "w", encoding="utf-8") as f:
             json.dump(report, f, indent=2)
 

--- a/privacy_pipeline/training.py
+++ b/privacy_pipeline/training.py
@@ -109,6 +109,17 @@ def train(cfg: ExperimentConfig, output_dir: str, plot_every: int = 5) -> Dict[s
             accountant.step(noise_multiplier=cfg.noise_mult, sample_rate=sample_rate)
             eps = accountant.get_epsilon(cfg.delta)
 
+            batch_pre = {
+                "l1_norm": float(np.mean(pre_l1)) if pre_l1 else 0.0,
+                "l2_norm": float(np.mean(pre_l2)) if pre_l2 else 0.0,
+                "cosine_similarity": float(np.mean(pre_cos)) if pre_cos else 0.0,
+            }
+            batch_post = {
+                "l1_norm": float(np.mean(post_l1)) if post_l1 else 0.0,
+                "l2_norm": float(np.mean(post_l2)) if post_l2 else 0.0,
+                "cosine_similarity": float(np.mean(post_cos)) if post_cos else 0.0,
+            }
+
             logger.log(
                 step_count,
                 {
@@ -119,6 +130,8 @@ def train(cfg: ExperimentConfig, output_dir: str, plot_every: int = 5) -> Dict[s
                     "clip_value": float(clip_val),
                     "grad_norm": float(grad_norm),
                     "lr": float(optimizer.param_groups[0]["lr"]),
+                    "pre_clip": batch_pre,
+                    "post_clip": batch_post,
                 },
             )
 
@@ -131,12 +144,16 @@ def train(cfg: ExperimentConfig, output_dir: str, plot_every: int = 5) -> Dict[s
             "loss": float(np.mean(losses)) if losses else 0.0,
             "accuracy": float(acc),
             "epsilon": float(eps),
-            "preclip_l1": _summary_stats(epoch_preclip_l1),
-            "preclip_l2": _summary_stats(epoch_preclip_l2),
-            "preclip_cos": _summary_stats(epoch_preclip_cos),
-            "postclip_l1": _summary_stats(epoch_postclip_l1),
-            "postclip_l2": _summary_stats(epoch_postclip_l2),
-            "postclip_cos": _summary_stats(epoch_postclip_cos),
+            "pre_clip": {
+                "l1_norm": _summary_stats(epoch_preclip_l1),
+                "l2_norm": _summary_stats(epoch_preclip_l2),
+                "cosine_similarity": _summary_stats(epoch_preclip_cos),
+            },
+            "post_clip": {
+                "l1_norm": _summary_stats(epoch_postclip_l1),
+                "l2_norm": _summary_stats(epoch_postclip_l2),
+                "cosine_similarity": _summary_stats(epoch_postclip_cos),
+            },
         }
         history.append(epoch_record)
 

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+from datetime import datetime
 
 
 def main() -> None:
@@ -20,7 +21,9 @@ def main() -> None:
     parser.add_argument(
         "--output",
         type=str,
-        default=os.path.join("outputs", "metrics.json"),
+        default=os.path.join(
+            "outputs", f"metrics_{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}.json"
+        ),
         help="Where to save metrics JSON",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- Log per-iteration and epoch-level L1, L2, and cosine similarity metrics in a standardized structure
- Save experiment metrics to timestamped JSON files to ensure uniqueness
- Use timestamped filenames by default when running experiments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891d6bfc93883269f0ae9b1660fc967